### PR TITLE
fix #61: add macro nutrient tracking

### DIFF
--- a/app/schemas/org.secuso.privacyfriendlyfoodtracker.database.ApplicationDatabase/1.json
+++ b/app/schemas/org.secuso.privacyfriendlyfoodtracker.database.ApplicationDatabase/1.json
@@ -1,0 +1,137 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "b441afa96955c4160952c91b7d440881",
+    "entities": [
+      {
+        "tableName": "ConsumedEntries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `productId` INTEGER NOT NULL, `amount` INTEGER NOT NULL, `date` INTEGER, `name` TEXT, FOREIGN KEY(`productId`) REFERENCES `Product`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Product",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "productId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Product",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `energy` REAL NOT NULL, `carbs` REAL NOT NULL, `sugar` REAL NOT NULL, `protein` REAL NOT NULL, `fat` REAL NOT NULL, `satFat` REAL NOT NULL, `barcode` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "energy",
+            "columnName": "energy",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "carbs",
+            "columnName": "carbs",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sugar",
+            "columnName": "sugar",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protein",
+            "columnName": "protein",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fat",
+            "columnName": "fat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "satFat",
+            "columnName": "satFat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "barcode",
+            "columnName": "barcode",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"b441afa96955c4160952c91b7d440881\")"
+    ]
+  }
+}

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/ConsumedEntrieAndProductDao.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/ConsumedEntrieAndProductDao.java
@@ -37,6 +37,37 @@ public interface ConsumedEntrieAndProductDao {
     @Query("SELECT consumedEntries.date AS unique1, sum(product.energy*consumedEntries.amount/100) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet")
     List<DateCalories> getCaloriesPeriod(final Date dayst, final Date dayet);
 
+    @Query("SELECT consumedEntries.date AS unique1, (sum(product.carbs*consumedEntries.amount)) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet GROUP BY consumedEntries.date ")
+    List<DateCalories> getCarbsPerDayinPeriod(final Date dayst, final Date dayet);
+
+    @Query("SELECT consumedEntries.date AS unique1, sum(product.carbs*consumedEntries.amount/100) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet")
+    List<DateCalories> getCarbsPeriod(final Date dayst, final Date dayet);
+
+    @Query("SELECT consumedEntries.date AS unique1, (sum(product.sugar*consumedEntries.amount)) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet GROUP BY consumedEntries.date ")
+    List<DateCalories> getSugarPerDayinPeriod(final Date dayst, final Date dayet);
+
+    @Query("SELECT consumedEntries.date AS unique1, sum(product.sugar*consumedEntries.amount/100) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet")
+    List<DateCalories> getSugarPeriod(final Date dayst, final Date dayet);
+
+    @Query("SELECT consumedEntries.date AS unique1, (sum(product.protein*consumedEntries.amount)) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet GROUP BY consumedEntries.date ")
+    List<DateCalories> getProteinPerDayinPeriod(final Date dayst, final Date dayet);
+
+    @Query("SELECT consumedEntries.date AS unique1, sum(product.protein*consumedEntries.amount/100) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet")
+    List<DateCalories> getProteinPeriod(final Date dayst, final Date dayet);
+
+    @Query("SELECT consumedEntries.date AS unique1, (sum(product.fat*consumedEntries.amount)) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet GROUP BY consumedEntries.date ")
+    List<DateCalories> getFatPerDayinPeriod(final Date dayst, final Date dayet);
+
+    @Query("SELECT consumedEntries.date AS unique1, sum(product.fat*consumedEntries.amount/100) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet")
+    List<DateCalories> getFatPeriod(final Date dayst, final Date dayet);
+
+    @Query("SELECT consumedEntries.date AS unique1, (sum(product.satFat*consumedEntries.amount)) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet GROUP BY consumedEntries.date ")
+    List<DateCalories> getSatFatPerDayinPeriod(final Date dayst, final Date dayet);
+
+    @Query("SELECT consumedEntries.date AS unique1, sum(product.satFat*consumedEntries.amount/100) AS unique2 FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id  WHERE consumedEntries.date BETWEEN :dayst AND :dayet")
+    List<DateCalories> getSatFatPeriod(final Date dayst, final Date dayet);
+
+
     static class DateCalories
     {
         public Date unique1;

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/Product.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/Product.java
@@ -32,12 +32,22 @@ public class Product {
     public final int id;
     public final String name;
     public final float energy;
+    public final float carbs;
+    public final float sugar;
+    public final float protein;
+    public final float fat;
+    public final float satFat;
     public final String barcode;
 
-    public Product(final int id, String name, float energy, String barcode) {
+    public Product(final int id, String name, float energy, float carbs, float sugar, float protein, float fat, float satFat, String barcode) {
         this.id = id;
         this.name = name;
         this.energy = energy;
+        this.carbs = carbs;
+        this.sugar = sugar;
+        this.protein = protein;
+        this.fat = fat;
+        this.satFat = satFat;
         this.barcode = barcode;
     }
 }

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/ProductDao.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/ProductDao.java
@@ -52,8 +52,8 @@ public interface ProductDao {
     @Query("SELECT * FROM product WHERE id=:id")
     Product findProductById(final int id);
 
-    @Query("SELECT * FROM product WHERE name=:name AND energy=:energy AND barcode=:barcode")
-    List<Product> findExistingProducts(String name, float energy, String barcode);
+    @Query("SELECT * FROM product WHERE name=:name AND energy=:energy AND carbs=:carbs AND sugar=:sugar AND protein=:protein AND fat=:fat AND satFat=:satFat AND barcode=:barcode")
+    List<Product> findExistingProducts(String name, float energy, float carbs, float sugar, float protein, float fat, float satFat, String barcode);
 
     @Query("SELECT * FROM product WHERE name LIKE :name")
     List<Product> findProductsByName(String name);

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/network/models/NetworkProduct.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/network/models/NetworkProduct.java
@@ -490,6 +490,57 @@ public class NetworkProduct {
         return "";
     }
 
+
+    /**
+     * @return The carbs per 100g
+     */
+    public String getNutrimentCarbs() {
+        if(nutriments.containsKey("carbohydrates_100g")){
+            return nutriments.get("carbohydrates_100g").toString();
+        }
+        return "";
+    }
+
+    /**
+     * @return The sugar per 100g
+     */
+    public String getNutrimentSugar() {
+        if(nutriments.containsKey("sugars_100g")){
+            return nutriments.get("sugars_100g").toString();
+        }
+        return "";
+    }
+
+    /**
+     * @return The protein per 100g
+     */
+    public String getNutrimentProtein() {
+        if(nutriments.containsKey("proteins_100g")){
+            return nutriments.get("proteins_100g").toString();
+        }
+        return "";
+    }
+
+    /**
+     * @return The fat per 100g
+     */
+    public String getNutrimentFat() {
+        if(nutriments.containsKey("fat_100g")){
+            return nutriments.get("fat_100g").toString();
+        }
+        return "";
+    }
+
+    /**
+     * @return The protein per 100g
+     */
+    public String getNutrimentSatFat() {
+        if(nutriments.containsKey("saturated-fat_100g")){
+            return nutriments.get("saturated-fat_100g").toString();
+        }
+        return "";
+    }
+
     /**
      * @return The Emb_codes
      */

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/network/utils/ProductConversionHelper.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/network/utils/ProductConversionHelper.java
@@ -19,7 +19,58 @@ public class ProductConversionHelper {
         } catch (NumberFormatException e){
             energy_100g = Float.parseFloat(product.getNutrimentEnergy()) / 4.184f;
         }
+
+        String carbsS = product.getNutrimentCarbs();
+        float carbs = 0;
+        if(!"".equals(carbsS)){
+            try {
+                carbs = Integer.parseInt(carbsS);
+            } catch (NumberFormatException e){
+                carbs = Float.parseFloat(carbsS);
+            }
+        }
+
+        String sugarS = product.getNutrimentSugar();
+        float sugar = 0;
+        if(!"".equals(sugarS)){
+            try {
+                sugar = Integer.parseInt(sugarS);
+            } catch (NumberFormatException e){
+                sugar = Float.parseFloat(sugarS);
+            }
+        }
+
+        String proteinS = product.getNutrimentProtein();
+        float protein = 0;
+        if(!"".equals(proteinS)){
+            try {
+                protein = Integer.parseInt(proteinS);
+            } catch (NumberFormatException e){
+                protein = Float.parseFloat(proteinS);
+            }
+        }
+
+        String fatS = product.getNutrimentFat();
+        float fat = 0;
+        if(!"".equals(fatS)){
+            try {
+                fat = Integer.parseInt(fatS);
+            } catch (NumberFormatException e){
+                fat = Float.parseFloat(fatS);
+            }
+        }
+
+        String satFatS = product.getNutrimentSatFat();
+        float satFat = 0;
+        if(!"".equals(satFatS)){
+            try {
+                satFat = Integer.parseInt(satFatS);
+            } catch (NumberFormatException e){
+                satFat = Float.parseFloat(satFatS);
+            }
+        }
+
         // if the id is equals to 0 then the room database creates a new id (primary key)
-        return new Product(0, product.getProductName(), energy_100g,  product.getCode());
+        return new Product(0, product.getProductName(), energy_100g, carbs, sugar, protein, fat, satFat, product.getCode());
     }
 }

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/AddFoodFragment.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/AddFoodFragment.java
@@ -50,6 +50,11 @@ public class AddFoodFragment extends Fragment {
     DatabaseFacade databaseFacade;
     EditText amountField;
     EditText caloriesField;
+    EditText carbsField;
+    EditText sugarField;
+    EditText proteinField;
+    EditText fatField;
+    EditText satFatField;
     /**
      * The required empty public constructor
      */
@@ -82,9 +87,23 @@ public class AddFoodFragment extends Fragment {
 
         amountField = parentHolder.findViewById(R.id.input_amount);
         caloriesField = parentHolder.findViewById(R.id.input_calories);
+        carbsField = parentHolder.findViewById(R.id.input_carbs);
+        sugarField = parentHolder.findViewById(R.id.input_sugar);
+        proteinField = parentHolder.findViewById(R.id.input_protein);
+        fatField = parentHolder.findViewById(R.id.input_fat);
+        satFatField = parentHolder.findViewById(R.id.input_satFat);
+
         amountField.setFilters(amountFilter);
         amountField.setInputType(InputType.TYPE_CLASS_NUMBER);
+
         caloriesField.setFilters(caloriesFilter);
+        carbsField.setFilters(caloriesFilter);
+        sugarField.setFilters(caloriesFilter);
+        proteinField.setFilters(caloriesFilter);
+        fatField.setFilters(caloriesFilter);
+        satFatField.setFilters(caloriesFilter);
+
+
         FloatingActionButton fab = parentHolder.findViewById(R.id.addEntry);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -96,11 +115,38 @@ public class AddFoodFragment extends Fragment {
 
                 String calories = caloriesField.getText().toString();
 
+                String carbs = carbsField.getText().toString();
+
+                String sugar = sugarField.getText().toString();
+
+                String protein = proteinField.getText().toString();
+
+                String fat = fatField.getText().toString();
+
+                String satFat = satFatField.getText().toString();
+
+
+                //replace empty macro slots with "0"
+                if("".equals(carbs)){
+                    carbs="0";
+                }
+                if("".equals(sugar)){
+                    sugar="0";
+                }
+                if("".equals(protein)){
+                    protein="0";
+                }
+                if("".equals(fat)){
+                    fat="0";
+                }
+                if("".equals(satFat)){
+                    satFat="0";
+                }
                 // validation
-                boolean validated = validateResponses(name, amount, calories, view);
+                boolean validated = validateResponses(name, amount, calories, carbs, sugar, protein, fat, satFat, view);
 
                 if(validated) {
-                    boolean entrySuccessful = makeDatabaseEntry(name, amount, calories);
+                    boolean entrySuccessful = makeDatabaseEntry(name, amount, calories, carbs, sugar, protein, fat, satFat);
                     if (!entrySuccessful){
                         showErrorMessage(view, R.string.error_database);
                     } else {
@@ -122,30 +168,102 @@ public class AddFoodFragment extends Fragment {
     @Override
     public void setUserVisibleHint(boolean isVisible) {
         super.setUserVisibleHint(isVisible);
+
         if(isVisible && referenceActivity.productSet) {
             EditText nameField = parentHolder.findViewById(R.id.input_food);
             EditText caloriesField = parentHolder.findViewById(R.id.input_calories);
+            EditText carbsField = parentHolder.findViewById(R.id.input_carbs);
+            EditText sugarField = parentHolder.findViewById(R.id.input_sugar);
+            EditText proteinField = parentHolder.findViewById(R.id.input_protein);
+            EditText fatField = parentHolder.findViewById(R.id.input_fat);
+            EditText satFatField = parentHolder.findViewById(R.id.input_satFat);
+
+
             nameField.setText(referenceActivity.name);
             nameField.setFocusable(false);
             nameField.setClickable(false);
             nameField.setTextColor(getResources().getColor(R.color.middlegrey));
+
             caloriesField.setText(String.format(Locale.ENGLISH, "%.2f", referenceActivity.calories));
             caloriesField.setFocusable(false);
             caloriesField.setClickable(false);
             caloriesField.setTextColor(getResources().getColor(R.color.middlegrey));
+
+            carbsField.setText(String.format(Locale.ENGLISH, "%.2f", referenceActivity.carbs));
+            carbsField.setFocusable(false);
+            carbsField.setClickable(false);
+            carbsField.setTextColor(getResources().getColor(R.color.middlegrey));
+
+            sugarField.setText(String.format(Locale.ENGLISH, "%.2f", referenceActivity.sugar));
+            sugarField.setFocusable(false);
+            sugarField.setClickable(false);
+            sugarField.setTextColor(getResources().getColor(R.color.middlegrey));
+
+            proteinField.setText(String.format(Locale.ENGLISH, "%.2f", referenceActivity.protein));
+            proteinField.setFocusable(false);
+            proteinField.setClickable(false);
+            proteinField.setTextColor(getResources().getColor(R.color.middlegrey));
+
+            fatField.setText(String.format(Locale.ENGLISH, "%.2f", referenceActivity.fat));
+            fatField.setFocusable(false);
+            fatField.setClickable(false);
+            fatField.setTextColor(getResources().getColor(R.color.middlegrey));
+
+            satFatField.setText(String.format(Locale.ENGLISH, "%.2f", referenceActivity.satFat));
+            satFatField.setFocusable(false);
+            satFatField.setClickable(false);
+            satFatField.setTextColor(getResources().getColor(R.color.middlegrey));
+
         } else if (isVisible && !referenceActivity.productSet) {
             EditText nameField = parentHolder.findViewById(R.id.input_food);
             EditText caloriesField = parentHolder.findViewById(R.id.input_calories);
+            EditText carbsField = parentHolder.findViewById(R.id.input_carbs);
+            EditText sugarField = parentHolder.findViewById(R.id.input_sugar);
+            EditText proteinField = parentHolder.findViewById(R.id.input_protein);
+            EditText fatField = parentHolder.findViewById(R.id.input_fat);
+            EditText satFatField = parentHolder.findViewById(R.id.input_satFat);
+
             nameField.setText("");
             nameField.setFocusable(true);
             nameField.setFocusableInTouchMode(true);
             nameField.setClickable(true);
             nameField.setTextColor(getResources().getColor(R.color.black));
+
             caloriesField.setText("");
             caloriesField.setFocusable(true);
             caloriesField.setFocusableInTouchMode(true);
             caloriesField.setClickable(true);
             caloriesField.setTextColor(getResources().getColor(R.color.black));
+
+            carbsField.setText("");
+            carbsField.setFocusable(true);
+            carbsField.setFocusableInTouchMode(true);
+            carbsField.setClickable(true);
+            carbsField.setTextColor(getResources().getColor(R.color.black));
+
+            sugarField.setText("");
+            sugarField.setFocusable(true);
+            sugarField.setFocusableInTouchMode(true);
+            sugarField.setClickable(true);
+            sugarField.setTextColor(getResources().getColor(R.color.black));
+
+            proteinField.setText("");
+            proteinField.setFocusable(true);
+            proteinField.setFocusableInTouchMode(true);
+            proteinField.setClickable(true);
+            proteinField.setTextColor(getResources().getColor(R.color.black));
+
+            fatField.setText("");
+            fatField.setFocusable(true);
+            fatField.setFocusableInTouchMode(true);
+            fatField.setClickable(true);
+            fatField.setTextColor(getResources().getColor(R.color.black));
+
+            satFatField.setText("");
+            satFatField.setFocusable(true);
+            satFatField.setFocusableInTouchMode(true);
+            satFatField.setClickable(true);
+            satFatField.setTextColor(getResources().getColor(R.color.black));
         }
     }
 
@@ -156,12 +274,18 @@ public class AddFoodFragment extends Fragment {
      * @param caloriesString calories per 100g
      * @return true if successful
      */
-    private boolean makeDatabaseEntry(String name, String amountString, String caloriesString) {
+    private boolean makeDatabaseEntry(String name, String amountString, String caloriesString, String carbsString, String sugarString, String proteinString, String fatString, String satFatString) {
         try {
             int amount = Integer.parseInt(amountString);
             float calories = Float.parseFloat(caloriesString);
+            float carbs = Float.parseFloat(carbsString);
+            float sugar = Float.parseFloat(sugarString);
+            float protein = Float.parseFloat(proteinString);
+            float fat = Float.parseFloat(fatString);
+            float satFat = Float.parseFloat(satFatString);
+
             // We haven't explicitly chosen a product so the productId is 0 for unknown
-            databaseFacade.insertEntry(amount, ((BaseAddFoodActivity) referenceActivity).date, name, calories, 0);
+            databaseFacade.insertEntry(amount, ((BaseAddFoodActivity) referenceActivity).date, name, calories, carbs, sugar, protein, fat, satFat, 0);
         } catch (Exception e) {
             // something went wrong so the entry wasn't successful
             e.printStackTrace();
@@ -178,7 +302,7 @@ public class AddFoodFragment extends Fragment {
      * @param view the view
      * @return returns true is all entries are valid
      */
-    private boolean validateResponses(String name, String amount, String calories, View view) {
+    private boolean validateResponses(String name, String amount, String calories, String carbs, String sugar, String protein, String fat, String satFat, View view) {
         if("".equals(name)){
             showErrorMessage(referenceActivity.findViewById(R.id.inputFoodName), R.string.error_food_missing);
             return false;
@@ -189,6 +313,8 @@ public class AddFoodFragment extends Fragment {
             showErrorMessage(referenceActivity.findViewById(R.id.inputCalories), R.string.error_calories_missing);
             return false;
         }
+
+
 
         try {
             Integer.parseInt(amount);
@@ -201,6 +327,24 @@ public class AddFoodFragment extends Fragment {
             Float.parseFloat(calories);
         } catch (NumberFormatException e) {
             showErrorMessage(referenceActivity.findViewById(R.id.inputCalories), R.string.error_calories_nan);
+            return false;
+        }
+        try {
+            Float.parseFloat(carbs);
+        } catch (NumberFormatException e) {
+            showErrorMessage(referenceActivity.findViewById(R.id.inputCalories), R.string.error_carbs_nan);
+            return false;
+        }
+        try {
+            Float.parseFloat(protein);
+        } catch (NumberFormatException e) {
+            showErrorMessage(referenceActivity.findViewById(R.id.inputCalories), R.string.error_protein_nan);
+            return false;
+        }
+        try {
+            Float.parseFloat(fat);
+        } catch (NumberFormatException e) {
+            showErrorMessage(referenceActivity.findViewById(R.id.inputCalories), R.string.error_fat_nan);
             return false;
         }
 

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/BaseAddFoodActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/BaseAddFoodActivity.java
@@ -43,6 +43,16 @@ public class BaseAddFoodActivity extends AppCompatActivity {
     String name;
     // Calories per 100g
     float calories;
+    // carbs per 100g
+    float carbs;
+    // sugar per 100g
+    float sugar;
+    // protein per 100g
+    float protein;
+    // fat per 100g
+    float fat;
+    // satFat of the product
+    float satFat;
     // ID of the product
     int id;
 

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/MonthStatisticFragment.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/MonthStatisticFragment.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.app.DatePickerDialog;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -43,6 +44,7 @@ import org.secuso.privacyfriendlyfoodtracker.database.ConsumedEntrieAndProductDa
 import org.secuso.privacyfriendlyfoodtracker.ui.viewmodels.SharedStatisticViewModel;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -61,6 +63,9 @@ public class MonthStatisticFragment extends Fragment {
     View parentHolder;
     TextView textView;
     DatabaseFacade databaseFacade;
+    TextView carbsTextView;
+    TextView proteinTextView;
+    TextView fatTextView;
 
     public MonthStatisticFragment() {
         // Required empty public constructor
@@ -80,6 +85,10 @@ public class MonthStatisticFragment extends Fragment {
             Log.e("Error", e.getMessage());
         }
         textView = parentHolder.findViewById(R.id.periodCalories1);
+        carbsTextView = parentHolder.findViewById(R.id.periodCarbs1);
+        proteinTextView = parentHolder.findViewById(R.id.periodProtein1);
+        fatTextView = parentHolder.findViewById(R.id.periodFat1);
+
         final TextView editText = (TextView) parentHolder.findViewById(R.id.datepicker);
         editText.setText(DateHelper.dateToString(sharedStatisticViewModel.getDate()));
         editText.setOnClickListener(new View.OnClickListener() {
@@ -132,16 +141,56 @@ public class MonthStatisticFragment extends Fragment {
 
     void UpdateGraph() {
 
+
         try {
 
             final Date startDate = getMonthByValue(-1);
             final Date endDate = getMonthByValue(0);
             List<ConsumedEntrieAndProductDao.DateCalories> consumedEntriesList = databaseFacade.getCaloriesPerDayinPeriod(startDate,endDate);
             List<ConsumedEntrieAndProductDao.DateCalories> calories = databaseFacade.getPeriodCalories(startDate,endDate);
+
+
             DataPoint[] dataPointInterfaces = new DataPoint[consumedEntriesList.size()];
             for (int i = 0; i < consumedEntriesList.size(); i++) {
                 dataPointInterfaces[i] = (new DataPoint(consumedEntriesList.get(i).unique1.getTime(), consumedEntriesList.get(i).unique2/100));
             }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedCarbsEntriesList = databaseFacade.getCarbsPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> carbs = databaseFacade.getPeriodCarbs(startDate, endDate);
+            DataPoint[] carbsDataPointInterfaces = new DataPoint[consumedCarbsEntriesList.size()];
+            for (int i = 0; i < consumedCarbsEntriesList.size(); i++) {
+                carbsDataPointInterfaces[i] = (new DataPoint(consumedCarbsEntriesList.get(i).unique1.getTime(), consumedCarbsEntriesList.get(i).unique2/100));
+            }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedSugarEntriesList = databaseFacade.getSugarPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> sugar = databaseFacade.getPeriodSugar(startDate, endDate);
+            DataPoint[] sugarDataPointInterfaces = new DataPoint[consumedSugarEntriesList.size()];
+            for (int i = 0; i < consumedSugarEntriesList.size(); i++) {
+                sugarDataPointInterfaces[i] = (new DataPoint(consumedSugarEntriesList.get(i).unique1.getTime(), consumedSugarEntriesList.get(i).unique2/100));
+            }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedProteinEntriesList = databaseFacade.getProteinPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> protein = databaseFacade.getPeriodProtein(startDate, endDate);
+            DataPoint[] proteinDataPointInterfaces = new DataPoint[consumedProteinEntriesList.size()];
+            for (int i = 0; i < consumedProteinEntriesList.size(); i++) {
+                proteinDataPointInterfaces[i] = (new DataPoint(consumedProteinEntriesList.get(i).unique1.getTime(), consumedProteinEntriesList.get(i).unique2/100));
+            }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedFatEntriesList = databaseFacade.getFatPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> fat = databaseFacade.getPeriodFat(startDate, endDate);
+            DataPoint[] fatDataPointInterfaces = new DataPoint[consumedFatEntriesList.size()];
+            for (int i = 0; i < consumedFatEntriesList.size(); i++) {
+                fatDataPointInterfaces[i] = (new DataPoint(consumedFatEntriesList.get(i).unique1.getTime(), consumedFatEntriesList.get(i).unique2/100));
+            }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedSatFatEntriesList = databaseFacade.getSatFatPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> satFat = databaseFacade.getPeriodSatFat(startDate, endDate);
+            DataPoint[] satFatDataPointInterfaces = new DataPoint[consumedSatFatEntriesList.size()];
+            for (int i = 0; i < consumedSatFatEntriesList.size(); i++) {
+                satFatDataPointInterfaces[i] = (new DataPoint(consumedSatFatEntriesList.get(i).unique1.getTime(), consumedSatFatEntriesList.get(i).unique2/100));
+            }
+
+
             if (calories.size() != 0) {
 
                 Calendar startDateCalendar = Calendar.getInstance();
@@ -153,6 +202,57 @@ public class MonthStatisticFragment extends Fragment {
                 float averageCalories = periodCalories/periodDays;
                 BigDecimal averageCaloriesBigDecimal = round(averageCalories,0) ;
                 textView.setText(averageCaloriesBigDecimal.toString());
+
+            }
+
+            Calendar startDateCalendar = Calendar.getInstance();
+            startDateCalendar.setTime(startDate);
+            Calendar endDateCalendar = Calendar.getInstance();
+            endDateCalendar.setTime(endDate);
+            float periodDays = daysBetween( endDateCalendar,startDateCalendar);
+
+            if (calories.size() != 0) {
+
+                float periodCalories = calories.get(0).unique2;
+                float averageCalories = periodCalories/periodDays;
+                BigDecimal averageCaloriesBigDecimal = round(averageCalories,0) ;
+                textView.setText(averageCaloriesBigDecimal.toString());
+
+            }
+            if (carbs.size() != 0 && sugar.size() != 0) {
+
+                float periodCarbs = carbs.get(0).unique2;
+                float averageCarbs = periodCarbs/periodDays;
+                BigDecimal averageCarbsBigDecimal = round(averageCarbs,0) ;
+
+                float periodSugar = sugar.get(0).unique2;
+                float averageSugar = periodSugar/periodDays;
+                BigDecimal averageSugarBigDecimal = round(averageSugar,0) ;
+
+                carbsTextView.setText(averageCarbsBigDecimal.toString() + "(" + averageSugarBigDecimal + ")");
+
+            }
+            if (protein.size() != 0) {
+
+                float periodProtein = protein.get(0).unique2;
+                float averageProtein = periodProtein/periodDays;
+                BigDecimal averageProteinBigDecimal = round(averageProtein,0) ;
+                proteinTextView.setText(averageProteinBigDecimal.toString());
+
+            }
+
+            if (fat.size() != 0 && satFat.size() != 0) {
+
+                float periodFat = fat.get(0).unique2;
+                float averageFat = periodFat/periodDays;
+                BigDecimal averageFatBigDecimal = round(averageFat,0) ;
+
+                float periodSatFat= satFat.get(0).unique2;
+                float averageSatFat = periodSatFat/periodDays;
+                BigDecimal averageSatFatBigDecimal = round(averageSatFat,0) ;
+
+                fatTextView.setText(averageFatBigDecimal.toString() + "(" + averageSatFatBigDecimal + ")");
+
             }
             GraphView graph = (GraphView) parentHolder.findViewById(R.id.graph);
             LineGraphSeries<DataPoint> series = new LineGraphSeries<>(dataPointInterfaces);
@@ -165,6 +265,55 @@ public class MonthStatisticFragment extends Fragment {
             graph.getGridLabelRenderer().setTextSize(40);
             graph.getViewport().setScrollable(true);
             graph.getGridLabelRenderer().setHorizontalLabelsAngle(135);
+
+
+            GraphView carbsGraph = (GraphView) parentHolder.findViewById(R.id.graphCarbs);
+            LineGraphSeries<DataPoint> carbsSeries = new LineGraphSeries<>(carbsDataPointInterfaces);
+            carbsGraph.addSeries(carbsSeries);
+            LineGraphSeries<DataPoint> sugarSeries = new LineGraphSeries<>(sugarDataPointInterfaces);
+            sugarSeries.setColor(Color.RED);
+            carbsGraph.addSeries(sugarSeries);
+            carbsGraph.getGridLabelRenderer().setLabelFormatter(new DateAsXAxisLabelFormatter(referenceActivity));
+            carbsGraph.getGridLabelRenderer().setHumanRounding(false, true);
+            carbsGraph.getViewport().setMinX(startDate.getTime());
+            carbsGraph.getViewport().setMaxX(endDate.getTime());
+            carbsGraph.getViewport().setXAxisBoundsManual(true);
+
+            carbsGraph.getGridLabelRenderer().setNumHorizontalLabels(7); // only 7 because of the space
+            carbsGraph.getGridLabelRenderer().setTextSize(40);
+            carbsGraph.getViewport().setScrollable(true);
+            carbsGraph.getGridLabelRenderer().setHorizontalLabelsAngle(135);
+
+            GraphView proteinGraph = (GraphView) parentHolder.findViewById(R.id.graphProtein);
+            LineGraphSeries<DataPoint> proteinSeries = new LineGraphSeries<>(proteinDataPointInterfaces);
+            proteinGraph.addSeries(proteinSeries);
+            proteinGraph.getGridLabelRenderer().setLabelFormatter(new DateAsXAxisLabelFormatter(referenceActivity));
+            proteinGraph.getGridLabelRenderer().setHumanRounding(false, true);
+            proteinGraph.getViewport().setMinX(startDate.getTime());
+            proteinGraph.getViewport().setMaxX(endDate.getTime());
+            proteinGraph.getViewport().setXAxisBoundsManual(true);
+
+            proteinGraph.getGridLabelRenderer().setNumHorizontalLabels(7); // only 7 because of the space
+            proteinGraph.getGridLabelRenderer().setTextSize(40);
+            proteinGraph.getViewport().setScrollable(true);
+            proteinGraph.getGridLabelRenderer().setHorizontalLabelsAngle(135);
+
+            GraphView fatGraph = (GraphView) parentHolder.findViewById(R.id.graphFat);
+            LineGraphSeries<DataPoint> fatSeries = new LineGraphSeries<>(fatDataPointInterfaces);
+            fatGraph.addSeries(fatSeries);
+            LineGraphSeries<DataPoint> satFatSeries = new LineGraphSeries<>(satFatDataPointInterfaces);
+            satFatSeries.setColor(Color.RED);
+            fatGraph.addSeries(satFatSeries);
+            fatGraph.getGridLabelRenderer().setLabelFormatter(new DateAsXAxisLabelFormatter(referenceActivity));
+            fatGraph.getGridLabelRenderer().setHumanRounding(false, true);
+            fatGraph.getViewport().setMinX(startDate.getTime());
+            fatGraph.getViewport().setMaxX(endDate.getTime());
+            fatGraph.getViewport().setXAxisBoundsManual(true);
+
+            fatGraph.getGridLabelRenderer().setNumHorizontalLabels(7); // only 7 because of the space
+            fatGraph.getGridLabelRenderer().setTextSize(40);
+            fatGraph.getViewport().setScrollable(true);
+            fatGraph.getGridLabelRenderer().setHorizontalLabelsAngle(135);
         } catch (Exception e) {
             Log.e("Error", e.getMessage());
         }

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/SearchFoodFragment.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/SearchFoodFragment.java
@@ -192,9 +192,37 @@ public class SearchFoodFragment extends Fragment {
                             cal = cal.split(" ")[0];
                             float calories = Float.parseFloat(cal);
 
+                            TextView carbView = childView.findViewById(R.id.resultCarbs);
+                            String carbsString = carbView.getText().toString();
+                            carbsString = carbsString.split(" ")[0];
+                            float carbs = Float.parseFloat(carbsString);
+
+                            String sugarString = carbView.getText().toString();
+                            sugarString = sugarString.split("\\(")[1].split("\\)")[0];
+                            float sugar = Float.parseFloat(sugarString);
+
+                            TextView protView = childView.findViewById(R.id.resultProtein);
+                            String prot = protView.getText().toString();
+                            prot = prot.split(" ")[0];
+                            float protein = Float.parseFloat(prot);
+
+                            TextView fatView = childView.findViewById(R.id.resultFat);
+                            String fatS = fatView.getText().toString();
+                            fatS = fatS.split(" ")[0];
+                            float fat = Float.parseFloat(fatS);
+
+                            String satFatS = fatView.getText().toString();
+                            satFatS = satFatS.split("\\(")[1].split("\\)")[0];
+                            float satFat = Float.parseFloat(satFatS);
+
                             ((BaseAddFoodActivity) referenceActivity).id = id;
                             ((BaseAddFoodActivity) referenceActivity).name = name;
                             ((BaseAddFoodActivity) referenceActivity).calories = calories;
+                            ((BaseAddFoodActivity) referenceActivity).carbs = carbs;
+                            ((BaseAddFoodActivity) referenceActivity).sugar = sugar;
+                            ((BaseAddFoodActivity) referenceActivity).protein = protein;
+                            ((BaseAddFoodActivity) referenceActivity).fat = fat;
+                            ((BaseAddFoodActivity) referenceActivity).satFat = satFat;
                             ((BaseAddFoodActivity) referenceActivity).productSet = true;
                             ViewPager pager = referenceActivity.findViewById(R.id.pager_food);
                             System.out.println("Setting page");

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/WeekStatisticFragment.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/WeekStatisticFragment.java
@@ -21,6 +21,7 @@ import android.app.Activity;
 import android.app.DatePickerDialog;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -31,6 +32,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.DatePicker;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.jjoe64.graphview.GraphView;
 import com.jjoe64.graphview.helper.DateAsXAxisLabelFormatter;
@@ -48,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import static org.secuso.privacyfriendlyfoodtracker.ui.helper.MathHelper.round;
 
@@ -63,6 +66,10 @@ public class WeekStatisticFragment extends Fragment {
     View parentHolder;
     TextView textView;
     DatabaseFacade databaseFacade;
+    TextView carbsTextView;
+    TextView proteinTextView;
+    TextView fatTextView;
+
     public WeekStatisticFragment() {
         // Required empty public constructor
     }
@@ -81,6 +88,10 @@ public class WeekStatisticFragment extends Fragment {
             Log.e("Error", e.getMessage());
         }
         textView = parentHolder.findViewById(R.id.periodCalories1);
+        carbsTextView = parentHolder.findViewById(R.id.periodCarbs1);
+        proteinTextView = parentHolder.findViewById(R.id.periodProtein1);
+        fatTextView = parentHolder.findViewById(R.id.periodFat1);
+
         final TextView editText = (TextView) parentHolder.findViewById(R.id.datepicker);
         editText.setText(DateHelper.dateToString(sharedStatisticViewModel.getDate()));
         editText.setOnClickListener(new View.OnClickListener() {
@@ -130,26 +141,81 @@ public class WeekStatisticFragment extends Fragment {
     }
 
     void UpdateGraph() {
-        List<ConsumedEntrieAndProductDao.DateCalories> consumedEntriesList = new ArrayList<>();
-        List<ConsumedEntrieAndProductDao.DateCalories> calories = new ArrayList<>();
+
         try {
 
             Date startDate = getWeekByValue(-1);
             Date endDate = getWeekByValue(0);
-            consumedEntriesList = databaseFacade.getCaloriesPerDayinPeriod(startDate,endDate);
-            calories = databaseFacade.getPeriodCalories(startDate,endDate);
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedEntriesList = databaseFacade.getCaloriesPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> calories = databaseFacade.getPeriodCalories(startDate, endDate);
             DataPoint[] dataPointInterfaces = new DataPoint[consumedEntriesList.size()];
             for (int i = 0; i < consumedEntriesList.size(); i++) {
                 dataPointInterfaces[i] = (new DataPoint(consumedEntriesList.get(i).unique1.getTime(), consumedEntriesList.get(i).unique2/100));
             }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedCarbsEntriesList = databaseFacade.getCarbsPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> carbs = databaseFacade.getPeriodCarbs(startDate, endDate);
+            DataPoint[] carbsDataPointInterfaces = new DataPoint[consumedCarbsEntriesList.size()];
+            for (int i = 0; i < consumedCarbsEntriesList.size(); i++) {
+                carbsDataPointInterfaces[i] = (new DataPoint(consumedCarbsEntriesList.get(i).unique1.getTime(), consumedCarbsEntriesList.get(i).unique2/100));
+            }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedSugarEntriesList = databaseFacade.getSugarPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> sugar = databaseFacade.getPeriodSugar(startDate, endDate);
+            DataPoint[] sugarDataPointInterfaces = new DataPoint[consumedSugarEntriesList.size()];
+            for (int i = 0; i < consumedSugarEntriesList.size(); i++) {
+                sugarDataPointInterfaces[i] = (new DataPoint(consumedSugarEntriesList.get(i).unique1.getTime(), consumedSugarEntriesList.get(i).unique2/100));
+            }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedProteinEntriesList = databaseFacade.getProteinPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> protein = databaseFacade.getPeriodProtein(startDate, endDate);
+            DataPoint[] proteinDataPointInterfaces = new DataPoint[consumedProteinEntriesList.size()];
+            for (int i = 0; i < consumedProteinEntriesList.size(); i++) {
+                proteinDataPointInterfaces[i] = (new DataPoint(consumedProteinEntriesList.get(i).unique1.getTime(), consumedProteinEntriesList.get(i).unique2/100));
+            }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedFatEntriesList = databaseFacade.getFatPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> fat = databaseFacade.getPeriodFat(startDate, endDate);
+            DataPoint[] fatDataPointInterfaces = new DataPoint[consumedFatEntriesList.size()];
+            for (int i = 0; i < consumedFatEntriesList.size(); i++) {
+                fatDataPointInterfaces[i] = (new DataPoint(consumedFatEntriesList.get(i).unique1.getTime(), consumedFatEntriesList.get(i).unique2/100));
+            }
+
+            List<ConsumedEntrieAndProductDao.DateCalories> consumedSatFatEntriesList = databaseFacade.getSatFatPerDayinPeriod(startDate, endDate);
+            List<ConsumedEntrieAndProductDao.DateCalories> satFat = databaseFacade.getPeriodSatFat(startDate, endDate);
+            DataPoint[] satFatDataPointInterfaces = new DataPoint[consumedSatFatEntriesList.size()];
+            for (int i = 0; i < consumedSatFatEntriesList.size(); i++) {
+                satFatDataPointInterfaces[i] = (new DataPoint(consumedSatFatEntriesList.get(i).unique1.getTime(), consumedSatFatEntriesList.get(i).unique2/100));
+            }
+
             int weekdays = 8;
 
             float averageCalories = calories.get(0).unique2 / weekdays;
+            float averageCarbs = carbs.get(0).unique2 / weekdays;
+            float averageSugar = sugar.get(0).unique2 / weekdays;
+            float averageProtein = protein.get(0).unique2 / weekdays;
+            float averageFat = fat.get(0).unique2 / weekdays;
+            float averageSatFat = satFat.get(0).unique2 / weekdays;
 
             BigDecimal averageCaloriesBigDecimal = round(averageCalories,0) ;
+            BigDecimal averageCarbsBigDecimal = round(averageCarbs,0) ;
+            BigDecimal averageSugarBigDecimal = round(averageSugar,0) ;
+            BigDecimal averageProteinBigDecimal = round(averageProtein,0) ;
+            BigDecimal averageFatBigDecimal = round(averageFat,0) ;
+            BigDecimal averageSatFatBigDecimal = round(averageSatFat,0) ;
 
             if (calories.size() != 0) {
                 textView.setText(averageCaloriesBigDecimal.toString());
+            }
+            if (carbs.size() != 0 && sugar.size() != 0) {
+                carbsTextView.setText(averageCarbsBigDecimal.toString() + " (" + averageSugarBigDecimal.toString() +")");
+            }
+            if (protein.size() != 0) {
+                proteinTextView.setText(averageProteinBigDecimal.toString());
+            }
+            if (fat.size() != 0 && satFat.size() != 0) {
+                fatTextView.setText(averageFatBigDecimal.toString() + " (" + averageSatFatBigDecimal.toString() +")");
             }
             GraphView graph = (GraphView) parentHolder.findViewById(R.id.graph);
             LineGraphSeries<DataPoint> series = new LineGraphSeries<>(dataPointInterfaces);
@@ -164,6 +230,54 @@ public class WeekStatisticFragment extends Fragment {
             graph.getGridLabelRenderer().setTextSize(40);
             graph.getViewport().setScrollable(true);
             graph.getGridLabelRenderer().setHorizontalLabelsAngle(135);
+
+            GraphView carbsGraph = (GraphView) parentHolder.findViewById(R.id.graphCarbs);
+            LineGraphSeries<DataPoint> carbsSeries = new LineGraphSeries<>(carbsDataPointInterfaces);
+            carbsGraph.addSeries(carbsSeries);
+            LineGraphSeries<DataPoint> sugarSeries = new LineGraphSeries<>(sugarDataPointInterfaces);
+            sugarSeries.setColor(Color.RED);
+            carbsGraph.addSeries(sugarSeries);
+            carbsGraph.getGridLabelRenderer().setLabelFormatter(new DateAsXAxisLabelFormatter(referenceActivity));
+            carbsGraph.getGridLabelRenderer().setHumanRounding(false, true);
+            carbsGraph.getViewport().setMinX(startDate.getTime());
+            carbsGraph.getViewport().setMaxX(endDate.getTime());
+            carbsGraph.getViewport().setXAxisBoundsManual(true);
+
+            carbsGraph.getGridLabelRenderer().setNumHorizontalLabels(7); // only 7 because of the space
+            carbsGraph.getGridLabelRenderer().setTextSize(40);
+            carbsGraph.getViewport().setScrollable(true);
+            carbsGraph.getGridLabelRenderer().setHorizontalLabelsAngle(135);
+
+            GraphView proteinGraph = (GraphView) parentHolder.findViewById(R.id.graphProtein);
+            LineGraphSeries<DataPoint> proteinSeries = new LineGraphSeries<>(proteinDataPointInterfaces);
+            proteinGraph.addSeries(proteinSeries);
+            proteinGraph.getGridLabelRenderer().setLabelFormatter(new DateAsXAxisLabelFormatter(referenceActivity));
+            proteinGraph.getGridLabelRenderer().setHumanRounding(false, true);
+            proteinGraph.getViewport().setMinX(startDate.getTime());
+            proteinGraph.getViewport().setMaxX(endDate.getTime());
+            proteinGraph.getViewport().setXAxisBoundsManual(true);
+
+            proteinGraph.getGridLabelRenderer().setNumHorizontalLabels(7); // only 7 because of the space
+            proteinGraph.getGridLabelRenderer().setTextSize(40);
+            proteinGraph.getViewport().setScrollable(true);
+            proteinGraph.getGridLabelRenderer().setHorizontalLabelsAngle(135);
+
+            GraphView fatGraph = (GraphView) parentHolder.findViewById(R.id.graphFat);
+            LineGraphSeries<DataPoint> fatSeries = new LineGraphSeries<>(fatDataPointInterfaces);
+            fatGraph.addSeries(fatSeries);
+            LineGraphSeries<DataPoint> satFatSeries = new LineGraphSeries<>(satFatDataPointInterfaces);
+            satFatSeries.setColor(Color.RED);
+            fatGraph.addSeries(satFatSeries);
+            fatGraph.getGridLabelRenderer().setLabelFormatter(new DateAsXAxisLabelFormatter(referenceActivity));
+            fatGraph.getGridLabelRenderer().setHumanRounding(false, true);
+            fatGraph.getViewport().setMinX(startDate.getTime());
+            fatGraph.getViewport().setMaxX(endDate.getTime());
+            fatGraph.getViewport().setXAxisBoundsManual(true);
+
+            fatGraph.getGridLabelRenderer().setNumHorizontalLabels(7); // only 7 because of the space
+            fatGraph.getGridLabelRenderer().setTextSize(40);
+            fatGraph.getViewport().setScrollable(true);
+            fatGraph.getGridLabelRenderer().setHorizontalLabelsAngle(135);
         } catch (Exception e) {
             Log.e("Error", e.getMessage());
         }

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/adapter/DatabaseEntry.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/adapter/DatabaseEntry.java
@@ -22,13 +22,23 @@ package org.secuso.privacyfriendlyfoodtracker.ui.adapter;
  */
 public class DatabaseEntry {
     public float energy;
+    public float carbs;
+    public float sugar;
+    public float protein;
+    public float fat;
+    public float satFat;
     public int amount;
     public String name;
     public String id;
-    public DatabaseEntry(String id, String name, int amount, float energy){
+    public DatabaseEntry(String id, String name, int amount, float energy, float carbs, float sugar, float protein, float fat, float satFat){
         this.id = id;
         this.amount = amount;
         this.energy = energy;
+        this.carbs = carbs;
+        this.sugar = sugar;
+        this.protein = protein;
+        this.fat = fat;
+        this.satFat = satFat;
         this.name = name;
     }
 }

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/adapter/DatabaseFacade.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/adapter/DatabaseFacade.java
@@ -55,16 +55,16 @@ public class DatabaseFacade {
      * @param name the name
      * @param productId the consumed product id
      */
-    public void insertEntry(final int amount, final java.util.Date date, final String name, final float energy, final int productId){
+    public void insertEntry(final int amount, final java.util.Date date, final String name, final float energy, final float carbs, final float sugar, final float protein, final float fat, final float satFat, final int productId){
         Executors.newSingleThreadExecutor().execute(new Runnable() {
             @Override
             public void run() {
                 int existingProductId = 0;
                 //If the productId is 0 we need to create a new product in the database
                 if (0 == productId) {
-                    insertProductPrivate(name, energy, "");
+                    insertProductPrivate(name, energy, carbs, sugar, protein, fat, satFat, "");
                     // retrieve ProductId of newly created Product from database
-                    List<Product> existingProducts = productDao.findExistingProducts(name, energy, "");
+                    List<Product> existingProducts = productDao.findExistingProducts(name, energy, carbs, sugar, protein, fat, satFat, "");
                     // There is only one existing product so we take the first one from the List
                     Product p = existingProducts.get(0);
                     existingProductId = p.id;
@@ -120,21 +120,21 @@ public class DatabaseFacade {
      * @param energy the energy
      * @param barcode the barcode
      */
-    public void insertProduct(final String name, final float energy, final String barcode){
+    public void insertProduct(final String name, final float energy, final float carbs, final float sugar, final float protein, final float fat, final float satFat, final String barcode){
         Executors.newSingleThreadExecutor().execute(new Runnable() {
             @Override
             public void run() {
-                insertProductPrivate(name, energy, barcode);
+                insertProductPrivate(name, energy, carbs,sugar, protein, fat, satFat, barcode);
             }
         });
     }
 
-    private void insertProductPrivate(String name, float energy, String barcode) {
-        List<Product> res = productDao.findExistingProducts(name, energy, barcode);
+    private void insertProductPrivate(String name, float energy, float carbs, float sugar, float protein, float fat, float satFat, String barcode) {
+        List<Product> res = productDao.findExistingProducts(name, energy, carbs, sugar, protein, fat, satFat, barcode);
         if (res.size() != 0) {
             return;
         }
-        productDao.insert(new Product(0, name, energy, barcode));
+        productDao.insert(new Product(0, name, energy, carbs, sugar, protein, fat, satFat, barcode));
     }
 
     /**
@@ -165,7 +165,7 @@ public class DatabaseFacade {
             List<ConsumedEntries> res = consumedEntriesDao.findConsumedEntriesForDate(new java.sql.Date(date.getTime()));
             for(ConsumedEntries consumedEntry : res) {
                 Product product = productDao.findProductById(consumedEntry.productId);
-                databaseEntries.add(new DatabaseEntry(String.valueOf(consumedEntry.id),consumedEntry.name, consumedEntry.amount, product.energy));
+                databaseEntries.add(new DatabaseEntry(String.valueOf(consumedEntry.id),consumedEntry.name, consumedEntry.amount, product.energy, product.carbs, product.sugar, product.protein, product.fat, product.satFat));
             }
 
         } catch (Exception e) {
@@ -192,6 +192,106 @@ public class DatabaseFacade {
      */
     public List<ConsumedEntrieAndProductDao.DateCalories> getCaloriesPerDayinPeriod(java.util.Date startDate, java.util.Date endDate){
         return consumedEntrieAndProductDao.getCaloriesPerDayinPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of carbs per day for a time period.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the carbs sum per day and the associated date
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getPeriodCarbs(java.util.Date startDate, java.util.Date endDate){
+        return    consumedEntrieAndProductDao.getCarbsPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of carbs between two dates.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the carbs sum (list position 0)
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getCarbsPerDayinPeriod(java.util.Date startDate, java.util.Date endDate){
+        return consumedEntrieAndProductDao.getCarbsPerDayinPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of sugar per day for a time period.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the sugar sum per day and the associated date
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getPeriodSugar(java.util.Date startDate, java.util.Date endDate){
+        return    consumedEntrieAndProductDao.getSugarPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of sugar between two dates.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the sugar sum (list position 0)
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getSugarPerDayinPeriod(java.util.Date startDate, java.util.Date endDate){
+        return consumedEntrieAndProductDao.getSugarPerDayinPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of protein per day for a time period.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the protein sum per day and the associated date
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getPeriodProtein(java.util.Date startDate, java.util.Date endDate){
+        return    consumedEntrieAndProductDao.getProteinPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of protein between two dates.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the protein sum (list position 0)
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getProteinPerDayinPeriod(java.util.Date startDate, java.util.Date endDate){
+        return consumedEntrieAndProductDao.getProteinPerDayinPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of fat per day for a time period.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the fat sum per day and the associated date
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getPeriodFat(java.util.Date startDate, java.util.Date endDate){
+        return    consumedEntrieAndProductDao.getFatPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of fat between two dates.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the fat sum (list position 0)
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getFatPerDayinPeriod(java.util.Date startDate, java.util.Date endDate){
+        return consumedEntrieAndProductDao.getFatPerDayinPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of saturated fat per day for a time period.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the fat sum per day and the associated date
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getPeriodSatFat(java.util.Date startDate, java.util.Date endDate){
+        return    consumedEntrieAndProductDao.getSatFatPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
+    }
+
+    /**
+     * Returns the sum of saturated fat between two dates.
+     * @param startDate the start date
+     * @param endDate the end date
+     * @return the fat sum (list position 0)
+     */
+    public List<ConsumedEntrieAndProductDao.DateCalories> getSatFatPerDayinPeriod(java.util.Date startDate, java.util.Date endDate){
+        return consumedEntrieAndProductDao.getSatFatPerDayinPeriod(new java.sql.Date(startDate.getTime()), new java.sql.Date(endDate.getTime()));
     }
 
     /**

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/adapter/SearchResultAdapter.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/adapter/SearchResultAdapter.java
@@ -93,6 +93,9 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultAdapte
         // - replace the contents of the view with that element
         ((TextView) holder.mCardView.findViewById(R.id.resultName)).setText(mDataset.get(position).name);
         ((TextView) holder.mCardView.findViewById(R.id.resultCalories)).setText(String.format(Locale.ENGLISH,"%.2f kCal", mDataset.get(position).energy));
+        ((TextView) holder.mCardView.findViewById(R.id.resultCarbs)).setText(String.format(Locale.ENGLISH,"%.2f (%.2f) g Carbs(sugar)", mDataset.get(position).carbs, mDataset.get(position).sugar));
+        ((TextView) holder.mCardView.findViewById(R.id.resultProtein)).setText(String.format(Locale.ENGLISH,"%.2f g Protein", mDataset.get(position).protein));
+        ((TextView) holder.mCardView.findViewById(R.id.resultFat)).setText(String.format(Locale.ENGLISH,"%.2f (%.2f) g Fat(sat. fat)", mDataset.get(position).fat, mDataset.get(position).satFat));
         ((TextView) holder.mCardView.findViewById(R.id.resultId)).setText(String.format(Locale.ENGLISH, "%d", mDataset.get(position).id));
     }
 

--- a/app/src/main/res/layout-land/content_food.xml
+++ b/app/src/main/res/layout-land/content_food.xml
@@ -6,69 +6,175 @@
     android:layout_height="match_parent"
     tools:context=".ui.BaseAddFoodActivity"
     android:fitsSystemWindows="true">
-<android.support.constraint.ConstraintLayout
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:showIn="@layout/activity_food"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin">
-
-    <android.support.design.widget.TextInputLayout
-        android:id="@+id/inputFoodName"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:errorEnabled="true"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:layout_editor_absoluteX="16dp">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+    <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:showIn="@layout/activity_food">
 
-        <EditText
-            android:id="@+id/input_food"
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputFoodName"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_food_name"
-            android:inputType="text"
-            android:maxLines="1" />
+            app:errorEnabled="true"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_editor_absoluteX="16dp">
 
-    </android.support.design.widget.TextInputLayout>
+            <EditText
+                android:id="@+id/input_food"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_name"
+                android:inputType="text"
+                android:maxLines="1" />
 
-    <android.support.design.widget.TextInputLayout
-        android:id="@+id/inputFoodAmount"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/inputFoodName"
-        app:errorEnabled="true">
+        </android.support.design.widget.TextInputLayout>
 
-        <EditText
-            android:id="@+id/input_amount"
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputFoodAmount"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_food_amount"
-            android:inputType="number"
-            android:maxLines="1"/>
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputFoodName">
 
-    </android.support.design.widget.TextInputLayout>
-    <android.support.design.widget.TextInputLayout
-        android:id="@+id/inputCalories"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/inputFoodAmount"
-        app:errorEnabled="true">
+            <EditText
+                android:id="@+id/input_amount"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_amount"
+                android:inputType="number"
+                android:maxLines="1" />
 
-        <EditText
-            android:id="@+id/input_calories"
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputCalories"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/hint_food_calories"
-            android:inputType="numberDecimal"
-            android:maxLines="1"/>
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputFoodAmount">
 
-    </android.support.design.widget.TextInputLayout>
+            <EditText
+                android:id="@+id/input_calories"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_calories"
+                android:inputType="numberDecimal"
+                android:maxLines="1" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputCarbs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputCalories">
 
 
-</android.support.constraint.ConstraintLayout>
+            <EditText
+                android:id="@+id/input_carbs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_carbs"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputSugar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputCarbs">
+
+
+            <EditText
+                android:id="@+id/input_sugar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_sugar"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputProtein"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputSugar">
+
+
+            <EditText
+                android:id="@+id/input_protein"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_protein"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputFat"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputProtein">
+
+
+            <EditText
+                android:id="@+id/input_fat"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_fat"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputSatFat"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputFat">
+
+
+            <EditText
+                android:id="@+id/input_satFat"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_satFat"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
+        </android.support.design.widget.TextInputLayout>
+
+
+    </android.support.constraint.ConstraintLayout>
+    </ScrollView>
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/addEntry"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/content_food.xml
+++ b/app/src/main/res/layout/content_food.xml
@@ -6,7 +6,10 @@
     android:layout_height="match_parent"
     tools:context=".ui.BaseAddFoodActivity"
     android:fitsSystemWindows="true">
-
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -67,10 +70,119 @@
                 android:inputType="numberDecimal"
                 android:maxLines="1" />
 
+
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputCarbs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputCalories">
+
+
+
+            <EditText
+                android:id="@+id/input_carbs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_carbs"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputSugar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputCarbs"
+            >
+
+
+            <EditText
+                android:id="@+id/input_sugar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_sugar"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputProtein"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputSugar">
+
+
+
+            <EditText
+                android:id="@+id/input_protein"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_protein"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputFat"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputProtein">
+
+
+
+            <EditText
+                android:id="@+id/input_fat"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_fat"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/inputSatFat"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:errorEnabled="true"
+            app:layout_constraintTop_toBottomOf="@+id/inputFat">
+
+
+
+            <EditText
+                android:id="@+id/input_satFat"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_food_satFat"
+                android:inputType="numberDecimal"
+                android:maxLines="1"
+                tools:layout_editor_absoluteX="45dp"
+                tools:layout_editor_absoluteY="235dp" />
+
         </android.support.design.widget.TextInputLayout>
 
 
+
     </android.support.constraint.ConstraintLayout>
+    </ScrollView>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/addEntry"

--- a/app/src/main/res/layout/content_overview.xml
+++ b/app/src/main/res/layout/content_overview.xml
@@ -22,6 +22,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+    <TextView
+        android:id="@+id/overviewMacros"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="TextView"
+        android:textAlignment="center"
+        android:textSize="15dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintLeft_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/overviewHeading" />
 
     <ScrollView
         android:layout_width="match_parent"
@@ -29,7 +39,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/overviewHeading">
+        app:layout_constraintTop_toBottomOf="@+id/overviewMacros">
 
         <android.widget.LinearLayout
             android:id="@+id/DailyList"

--- a/app/src/main/res/layout/fragment_month_statistic.xml
+++ b/app/src/main/res/layout/fragment_month_statistic.xml
@@ -108,6 +108,67 @@
                         android:id="@+id/graph"
                         android:layout_width="match_parent"
                         android:layout_height="200dip" />
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/carbsPerWeek" />
+
+                        <TextView
+                            android:id="@+id/periodCarbs1"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+                    <com.jjoe64.graphview.GraphView
+                        android:id="@+id/graphCarbs"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dip" />
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/proteinPerWeek" />
+
+                        <TextView
+                            android:id="@+id/periodProtein1"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+                    <com.jjoe64.graphview.GraphView
+                        android:id="@+id/graphProtein"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dip" />
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/fatPerWeek" />
+
+                        <TextView
+                            android:id="@+id/periodFat1"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+                    <com.jjoe64.graphview.GraphView
+                        android:id="@+id/graphFat"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dip" />
                 </LinearLayout>
 
             </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/fragment_week_statistic.xml
+++ b/app/src/main/res/layout/fragment_week_statistic.xml
@@ -109,6 +109,66 @@
                         android:id="@+id/graph"
                         android:layout_width="match_parent"
                         android:layout_height="200dip" />
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/carbsPerWeek" />
+
+                        <TextView
+                            android:id="@+id/periodCarbs1"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+                    <com.jjoe64.graphview.GraphView
+                        android:id="@+id/graphCarbs"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dip" />
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/proteinPerWeek" />
+
+                        <TextView
+                            android:id="@+id/periodProtein1"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+                    <com.jjoe64.graphview.GraphView
+                        android:id="@+id/graphProtein"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dip" />
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/fatPerWeek" />
+
+                        <TextView
+                            android:id="@+id/periodFat1"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+                    <com.jjoe64.graphview.GraphView
+                        android:id="@+id/graphFat"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dip" />
                 </LinearLayout>
 
             </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/search_result.xml
+++ b/app/src/main/res/layout/search_result.xml
@@ -32,6 +32,40 @@
             app:layout_constraintHorizontal_chainStyle="spread"
             />
         <TextView
+            android:layout_width="0dp"
+            android:paddingRight="2dp"
+            android:layout_height="wrap_content"
+            android:id="@+id/resultCarbs"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintLeft_toRightOf="@id/resultName"
+            app:layout_constraintTop_toBottomOf="@id/resultCalories"
+            android:text="test"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            />
+        <TextView
+            android:layout_width="0dp"
+            android:paddingRight="2dp"
+            android:layout_height="wrap_content"
+            android:id="@+id/resultProtein"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintLeft_toRightOf="@id/resultName"
+            app:layout_constraintTop_toBottomOf="@id/resultCarbs"
+            android:text="test"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            />
+        <TextView
+            android:layout_width="0dp"
+            android:paddingRight="2dp"
+            android:layout_height="wrap_content"
+            android:id="@+id/resultFat"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintLeft_toRightOf="@id/resultName"
+            app:layout_constraintTop_toBottomOf="@id/resultProtein"
+
+            android:text="test"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            />
+        <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/resultId"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,4 +110,16 @@
     <string name="save">Save</string>
 
     <string name="search_for">Search for a product</string>
+    <string name="error_carbs_nan" >Only numbers are allowed for carbs</string>
+    <string name="error_protein_nan" >Only numbers are allowed for protein</string>
+    <string name="error_fat_nan" >Only numbers are allowed for fat</string>
+    <string name="hint_food_macros">g/100g</string>
+    <string name="hint_food_carbs">Carbs in g/100g</string>
+    <string name="hint_food_protein">Protein in g/100g</string>
+    <string name="hint_food_fat">Fat in g/100g</string>
+    <string name="carbsPerWeek">Average carbs (sugar) per day</string>
+    <string name="proteinPerWeek">Average protein per day</string>
+    <string name="fatPerWeek">Average fat (saturated fat) per day</string>
+    <string name="hint_food_sugar">Sugar in g/100g</string>
+    <string name="hint_food_satFat">Saturated Fat in g/100g</string>
 </resources>


### PR DESCRIPTION
This enhances the app so users can add macro nutrients to the products they add. The macro nutrients for each entry are listed in the overview and below the overview heading the total macros are shown also. Products added from the OpenFoodFacts search also contain macros - if OFF provides them. The statisitics show a graph view for every macro below the energy graph view - carbs & sugar and fat & saturated fat each share a graph view.

I was not able to test how this enhacement works when updating an existing version of the app, I guess there need changes to be done to some database stuff, so that the upgrade works.