### PR TITLE
fix #79: weekly average not calculated correctly

### DIFF
--- a/app/schemas/org.secuso.privacyfriendlyfoodtracker.database.ApplicationDatabase/1.json
+++ b/app/schemas/org.secuso.privacyfriendlyfoodtracker.database.ApplicationDatabase/1.json
@@ -1,0 +1,107 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "1c4b4d71bcbdb586cc4af0a0585902ca",
+    "entities": [
+      {
+        "tableName": "ConsumedEntries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `productId` INTEGER NOT NULL, `amount` INTEGER NOT NULL, `date` INTEGER, `name` TEXT, FOREIGN KEY(`productId`) REFERENCES `Product`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "productId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": [
+          {
+            "table": "Product",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "productId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Product",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `energy` REAL NOT NULL, `barcode` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "energy",
+            "columnName": "energy",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "barcode",
+            "columnName": "barcode",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"1c4b4d71bcbdb586cc4af0a0585902ca\")"
+    ]
+  }
+}

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/MonthStatisticFragment.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/MonthStatisticFragment.java
@@ -134,8 +134,8 @@ public class MonthStatisticFragment extends Fragment {
 
         try {
 
-            final Date startDate = getMonthByValue(-1);
-            final Date endDate = getMonthByValue(0);
+            final Date startDate = DateHelper.changeDateTimeToMidnight(getMonthByValue(-1));
+            final Date endDate = DateHelper.changeDateTimeToMidnight(getMonthByValue(0));
             List<ConsumedEntrieAndProductDao.DateCalories> consumedEntriesList = databaseFacade.getCaloriesPerDayinPeriod(startDate,endDate);
             List<ConsumedEntrieAndProductDao.DateCalories> calories = databaseFacade.getPeriodCalories(startDate,endDate);
             DataPoint[] dataPointInterfaces = new DataPoint[consumedEntriesList.size()];

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/WeekStatisticFragment.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/WeekStatisticFragment.java
@@ -135,14 +135,16 @@ public class WeekStatisticFragment extends Fragment {
         try {
 
             Date startDate = getWeekByValue(-1);
+            startDate = DateHelper.changeDateTimeToMidnight(startDate); //set time to midnight so the period does not depend on the time of day
             Date endDate = getWeekByValue(0);
+            endDate = DateHelper.changeDateTimeToMidnight(endDate);
             consumedEntriesList = databaseFacade.getCaloriesPerDayinPeriod(startDate,endDate);
             calories = databaseFacade.getPeriodCalories(startDate,endDate);
             DataPoint[] dataPointInterfaces = new DataPoint[consumedEntriesList.size()];
             for (int i = 0; i < consumedEntriesList.size(); i++) {
                 dataPointInterfaces[i] = (new DataPoint(consumedEntriesList.get(i).unique1.getTime(), consumedEntriesList.get(i).unique2/100));
             }
-            int weekdays = 8;
+            int weekdays = 7;
 
             float averageCalories = calories.get(0).unique2 / weekdays;
 
@@ -180,5 +182,6 @@ public class WeekStatisticFragment extends Fragment {
         Date date = DateHelper.changeWeek(sharedStatisticViewModel.getDate(), value);
         return date;
     }
+
 
 }

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/helper/DateHelper.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/helper/DateHelper.java
@@ -51,4 +51,20 @@ public class DateHelper {
         DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.SHORT, Locale.getDefault());
         return dateFormat.format(date);
     }
+
+    /**
+     * Sets a given Date's time to 00:00:00.00, so getting a weeks daily calories works reliably.
+     * @param date the date whose time shall be midnight
+     * @return the new changed date
+     */
+    public static Date changeDateTimeToMidnight(Date date){
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+        return calendar.getTime();
+    }
 }


### PR DESCRIPTION
Privacy - to indicate I read CONTRIBUTING.md

This fixes #79 . The average was not calculated correctly due to the start and end date used in the database query. Since the dates contained the current time (e.g. 18:30:23), entries made before that time on the first day of the period were not considered for the calculation. This is fixed by handing dates with time set to 00:00:00.00 in to the database query.