### PR TITLE
Add product lookup by barcode in search view

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/network/ProductApiService.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/network/ProductApiService.java
@@ -17,6 +17,7 @@ along with Privacy friendly food tracker.  If not, see <https://www.gnu.org/lice
 package org.secuso.privacyfriendlyfoodtracker.network;
 
 import org.secuso.privacyfriendlyfoodtracker.network.models.ProductResponse;
+import org.secuso.privacyfriendlyfoodtracker.network.models.ProductApiResponse;
 
 import java.util.List;
 
@@ -37,4 +38,7 @@ public interface ProductApiService {
 
     @GET("/cgi/search.pl?product_size=1&search_simple=0&action=process&json=1")
     Call<ProductResponse> listProductsFromPage(@Query("search_terms") String productName, @Query("page") String page );
+
+    @GET("/api/v0/product/{barcode}.json")
+    Call<ProductApiResponse> getProductFromBarcode(@Path("barcode") String barcode);
 }

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/network/models/ProductApiResponse.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/network/models/ProductApiResponse.java
@@ -1,0 +1,28 @@
+/*
+This file is part of Privacy friendly food tracker.
+
+Privacy friendly food tracker is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Privacy friendly food tracker is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Privacy friendly food tracker.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package org.secuso.privacyfriendlyfoodtracker.network.models;
+
+/**
+ * Java Model for the JSON Open Food Facts response. Represents a single product.
+ */
+public class ProductApiResponse {
+    public String code;
+    public int status;
+    public String status_verbose;
+    public NetworkProduct product;
+}


### PR DESCRIPTION
Allows entering a barcode that is used to look up product information directly, instead of showing a search results page. This functionality is enabled if the entered string consists of only digits.

Provides a start towards fixing #89, but doesn't go as far as adding scanning functionality. Instead, relies on the user either entering a barcode manually, or using an app like the OFF app to scan a barcode and copying it from there.

Privacy