### PR TITLE
Feature: Sharing of the database 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,7 @@ dependencies {
 
     implementation 'com.android.support:recyclerview-v7:28.0.0'
 
-
+    //JSON Sanitizer
+    implementation 'com.mikesamuel:json-sanitizer:[1.0,)'
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,10 +15,35 @@
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <activity
+            android:name=".database.importexport.DbImpExpFileReceivedActivity"
+            android:exported="true"
+            android:label="@string/title_activity_db_imp_exp_file_received"
+            android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter android:label="import">
+                <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.PICK" />
+                <action android:name="android.intent.action.PICK_ACTIVITY" />
+                <action android:name="android.intent.action.GET_CONTENT" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="application/json" />
+                <data android:mimeType="text/*" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".ui.DatabaseActivity"
+            android:exported="false"
+            android:label="@string/title_activity_database"
+            android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".ui.SplashActivity"
             android:theme="@style/SplashTheme">
@@ -74,13 +99,23 @@
             android:name=".ui.BaseStatisticActivity"
             android:label="@string/action_statistic"
             android:parentActivityName=".ui.MainActivity"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
+            android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".ui.BaseAddFoodActivity"
             android:label="@string/title_activity_food"
             android:parentActivityName=".ui.OverviewActivity"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="adjustResize"></activity>
+            android:windowSoftInputMode="adjustResize" />
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/assets/dbimpex.properties
+++ b/app/src/main/assets/dbimpex.properties
@@ -1,0 +1,1 @@
+db.impex.prefix=PrivacyFriendlyFoodTracker

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/ConsumedEntrieAndProductDao.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/ConsumedEntrieAndProductDao.java
@@ -20,8 +20,6 @@ import android.arch.lifecycle.LiveData;
 import android.arch.persistence.room.Dao;
 import android.arch.persistence.room.Query;
 
-import com.jjoe64.graphview.series.DataPoint;
-
 import org.secuso.privacyfriendlyfoodtracker.ui.adapter.DatabaseEntry;
 
 import java.sql.Date;
@@ -43,8 +41,13 @@ public interface ConsumedEntrieAndProductDao {
     @Query("SELECT consumedEntries.amount AS amount, consumedEntries.id AS id,consumedEntries.name as name, product.energy as energy FROM consumedEntries INNER JOIN product ON consumedEntries.productId = product.id WHERE consumedEntries.date=:day")
     LiveData<List<DatabaseEntry>> findConsumedEntriesForDate(final Date day);
 
-    static class DateCalories
-    {
+    @Query("SELECT * FROM consumedentries")
+    List<ConsumedEntries> getAllConsumedEntries();
+
+    @Query("SELECT * FROM product")
+    List<Product> getAllProducts();
+
+    static class DateCalories {
         public Date unique1;
         public int unique2;
     }

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/ConsumedEntriesDao.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/ConsumedEntriesDao.java
@@ -16,7 +16,6 @@ along with Privacy friendly food tracker.  If not, see <https://www.gnu.org/lice
 */
 package org.secuso.privacyfriendlyfoodtracker.database;
 
-import android.arch.lifecycle.LiveData;
 import android.arch.persistence.room.Dao;
 import android.arch.persistence.room.Delete;
 import android.arch.persistence.room.Insert;
@@ -55,7 +54,7 @@ public interface ConsumedEntriesDao {
     List<ConsumedEntries> findConsumedEntriesBetweenDates(final Date dayst, final Date dayet);
 
     @Query("SELECT * FROM consumedEntries WHERE id=:id")
-    List<ConsumedEntries> findConsumedEntriesById(final int id);
+    ConsumedEntries findConsumedEntriesById(final int id);
 
     @Query("SELECT * FROM consumedEntries WHERE productId=:productId AND amount=:amount AND date=:date AND name=:name  ")
     List<ConsumedEntries> findExistingConsumedEntries( int productId, int amount,  Date date, String name);

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/importexport/DatabaseExporter.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/importexport/DatabaseExporter.java
@@ -1,0 +1,80 @@
+package org.secuso.privacyfriendlyfoodtracker.database.importexport;
+
+import android.content.Context;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import org.secuso.privacyfriendlyfoodtracker.database.ApplicationDatabase;
+import org.secuso.privacyfriendlyfoodtracker.database.ConsumedEntries;
+import org.secuso.privacyfriendlyfoodtracker.database.Product;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class DatabaseExporter {
+
+    private Context context;
+
+    public DatabaseExporter(Context context) {
+        this.context = context;
+    }
+
+    public int getNumberOfProducts() {
+        try {
+            return ApplicationDatabase.getInstance(context).getProductDao().getAllProducts().getValue().size();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return 0;
+        }
+    }
+
+    public int getNumberOfConsumedEntries() {
+        try {
+            return ApplicationDatabase.getInstance(context).getConsumedEntriesDao().getAllConsumedEntries().size();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return 0;
+        }
+    }
+
+    public String exportDatabase() {
+        try {
+            List<Product> products = ApplicationDatabase.getInstance(context).getProductDao().getAllProducts().getValue();
+            List<ConsumedEntries> consumedEntries = ApplicationDatabase.getInstance(context).getConsumedEntriesDao().getAllConsumedEntries();
+            ImpExModel model = new ImpExModel();
+            model.setProductList(products);
+            model.setConsumedEntriesList(consumedEntries);
+
+            //convert to json string
+            Type listType = new TypeToken<ImpExModel>() {
+            }.getType();
+            Gson gson = new Gson();
+            String json = gson.toJson(model, listType);
+            return json;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+
+    public String exportProductDatabase() {
+        try {
+            List<Product> products = ApplicationDatabase.getInstance(context).getProductDao().getAllProducts().getValue();
+            ImpExModel model = new ImpExModel();
+            model.setProductList(products);
+            model.setConsumedEntriesList(null);
+
+            //convert to json string
+            Type listType = new TypeToken<ImpExModel>() {
+            }.getType();
+            Gson gson = new Gson();
+            String json = gson.toJson(model, listType);
+            return json;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+
+}

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/importexport/DatabaseImporter.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/importexport/DatabaseImporter.java
@@ -1,0 +1,70 @@
+package org.secuso.privacyfriendlyfoodtracker.database.importexport;
+
+import android.content.Context;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import org.secuso.privacyfriendlyfoodtracker.database.ApplicationDatabase;
+import org.secuso.privacyfriendlyfoodtracker.database.ConsumedEntries;
+import org.secuso.privacyfriendlyfoodtracker.database.ConsumedEntriesDao;
+import org.secuso.privacyfriendlyfoodtracker.database.Product;
+import org.secuso.privacyfriendlyfoodtracker.database.ProductDao;
+
+import java.lang.reflect.Type;
+
+public class DatabaseImporter {
+    private Context context;
+    ApplicationDatabase database;
+
+    public DatabaseImporter(Context context) {
+        this.context = context;
+        try {
+            this.database = ApplicationDatabase.getInstance(context);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void importDatabase(String json) {
+        Gson gson = new Gson();
+        Type listType = new TypeToken<ImpExModel>() {
+        }.getType();
+        int products = 0;
+        int entries = 0;
+        try {
+            ImpExModel impExModel = gson.fromJson(json, listType);
+            ProductDao productDao = database.getProductDao();
+            ConsumedEntriesDao consumedEntriesDao = database.getConsumedEntriesDao();
+            if (null != impExModel.getProductList()) {
+                for (Product product : impExModel.getProductList()) {
+                    Product p = productDao.findProductById(product.id);
+                    if (null == p) {
+                        productDao.insert(product);
+                    } else {
+                        productDao.update(product);
+                    }
+                }
+                products = impExModel.getProductList().size();
+            }
+            if (null != impExModel.getConsumedEntriesList()) {
+                for (ConsumedEntries entity : impExModel.getConsumedEntriesList()) {
+                    ConsumedEntries ent = consumedEntriesDao.findConsumedEntriesById(entity.id);
+                    if (null == ent) {
+                        consumedEntriesDao.insert(entity);
+                    } else {
+                        consumedEntriesDao.update(entity);
+                    }
+                }
+                entries = impExModel.getConsumedEntriesList().size();
+            }
+        } catch (Exception e) {
+            Log.e(DatabaseImporter.class.toString(), e.getMessage());
+            Toast.makeText(context, "Failed to import database: " + e.getMessage(), Toast.LENGTH_LONG).show();
+        }
+        Toast.makeText(context, "DB Import successful for " + products + " products and " + entries + " entries.", Toast.LENGTH_LONG).show();
+    }
+
+}

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/importexport/DbImpExpFileReceivedActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/importexport/DbImpExpFileReceivedActivity.java
@@ -1,0 +1,72 @@
+package org.secuso.privacyfriendlyfoodtracker.database.importexport;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+import com.google.gson.Gson;
+import com.google.json.JsonSanitizer;
+
+import org.secuso.privacyfriendlyfoodtracker.R;
+import org.secuso.privacyfriendlyfoodtracker.ui.helper.BaseActivity;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class DbImpExpFileReceivedActivity extends BaseActivity {
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        DatabaseImporter dbImporter = new DatabaseImporter(this.getApplicationContext());
+        // Get intent, action and MIME type
+        Intent intent = getIntent();
+        String action = intent.getAction();
+        String type = intent.getType();
+
+        if (Intent.ACTION_SEND.equals(action) || Intent.ACTION_VIEW.equals(action) && type != null) {
+            if ("application/json".equals(type)) {
+                // handle db file import
+                String content = readData(intent.getData());
+                if (isJson(content)) {
+                    String wellFormedJson = JsonSanitizer.sanitize(content);
+                    dbImporter.importDatabase(wellFormedJson);
+                }
+            }
+        }
+    }
+
+    public static boolean isJson(String jsonInString) {
+        try {
+            Gson gson = new Gson();
+            gson.fromJson(jsonInString, Object.class);
+            return true;
+        } catch (com.google.gson.JsonSyntaxException ex) {
+            return false;
+        }
+    }
+
+    private String readData(Uri uri) {
+        String content = "";
+        try {
+            InputStream in = getContentResolver().openInputStream(uri);
+            BufferedReader r = new BufferedReader(new InputStreamReader(in));
+            StringBuilder total = new StringBuilder();
+            for (String line; (line = r.readLine()) != null; ) {
+                total.append(line).append('\n');
+            }
+            content = total.toString();
+        } catch (Exception e) {
+
+        }
+        return content;
+    }
+
+    @Override
+    protected int getNavigationDrawerID() {
+        return R.id.nav_database;
+    }
+}

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/importexport/ImpExModel.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/database/importexport/ImpExModel.java
@@ -1,0 +1,27 @@
+package org.secuso.privacyfriendlyfoodtracker.database.importexport;
+
+import org.secuso.privacyfriendlyfoodtracker.database.ConsumedEntries;
+import org.secuso.privacyfriendlyfoodtracker.database.Product;
+
+import java.util.List;
+
+public class ImpExModel {
+    private List<Product> productList;
+    private List<ConsumedEntries> consumedEntriesList;
+
+    public List<Product> getProductList() {
+        return productList;
+    }
+
+    public void setProductList(List<Product> productList) {
+        this.productList = productList;
+    }
+
+    public List<ConsumedEntries> getConsumedEntriesList() {
+        return consumedEntriesList;
+    }
+
+    public void setConsumedEntriesList(List<ConsumedEntries> consumedEntriesList) {
+        this.consumedEntriesList = consumedEntriesList;
+    }
+}

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/helpers/PropertyHelper.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/helpers/PropertyHelper.java
@@ -1,0 +1,30 @@
+package org.secuso.privacyfriendlyfoodtracker.helpers;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.util.Log;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropertyHelper {
+
+    private final static String IMPEX_PROPERTY_FILENAME = "dbimpex.properties";
+
+    public static String getImpExProperty(String key, Context context) throws IOException {
+        Properties properties = new Properties();
+        ;
+        AssetManager assetManager = context.getAssets();
+        try {
+
+            InputStream inputStream = assetManager.open(IMPEX_PROPERTY_FILENAME);
+            properties.load(inputStream);
+            return properties.getProperty(key);
+        } catch (Exception e) {
+            Log.e(PropertyHelper.class.toString(), e.getMessage());
+            e.printStackTrace();
+            return "";
+        }
+    }
+}

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/DatabaseActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/DatabaseActivity.java
@@ -1,0 +1,135 @@
+/*
+This file is part of Privacy friendly food tracker.
+Privacy friendly food tracker is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+Privacy friendly food tracker is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with Privacy friendly food tracker.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package org.secuso.privacyfriendlyfoodtracker.ui;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v4.content.FileProvider;
+import android.view.View;
+import android.widget.TextView;
+
+import org.secuso.privacyfriendlyfoodtracker.R;
+import org.secuso.privacyfriendlyfoodtracker.database.importexport.DatabaseExporter;
+import org.secuso.privacyfriendlyfoodtracker.helpers.PropertyHelper;
+import org.secuso.privacyfriendlyfoodtracker.ui.helper.BaseActivity;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Displays an "about" page
+ *
+ * @author Jürgen Breitenbaumer, juergenbr
+ */
+public class DatabaseActivity extends BaseActivity {
+
+    private Intent intentShareFile = new Intent(Intent.ACTION_SEND);
+    private DatabaseExporter dbExporter;
+
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        dbExporter = new DatabaseExporter(this.getApplicationContext());
+        setContentView(R.layout.activity_database);
+        TextView textProducts = (TextView) findViewById(R.id.text_products);
+        textProducts.setText(getResources().getString(R.string.db_number_products) + " " + dbExporter.getNumberOfProducts());
+        TextView consumedEntries = (TextView) findViewById(R.id.text_conssumedentries);
+        consumedEntries.setText(getResources().getString(R.string.db_number_consumedentries) + " " + dbExporter.getNumberOfConsumedEntries());
+    }
+
+    protected int getNavigationDrawerID() {
+        return R.id.nav_database;
+    }
+
+    public void onClickExportBtn(View v) {
+        try {
+            String dbJsonString = "";
+            String pattern = "dd-MM-yyyy";
+            String dateInString = new SimpleDateFormat(pattern).format(new Date());
+            String filename = PropertyHelper.getImpExProperty("db.impex.prefix", this.getApplicationContext()) + "_" + dateInString + ".json";
+            if (v.getId() == R.id.export_button) {
+                dbJsonString = dbExporter.exportDatabase();
+            } else if (v.getId() == R.id.export_products_button) {
+                dbJsonString = dbExporter.exportProductDatabase();
+                filename = PropertyHelper.getImpExProperty("db.impex.prefix", this.getApplicationContext()) + "_products_" + dateInString + ".json";
+            }
+            if (dbJsonString != "") {
+
+                this.create(this.getApplicationContext(), filename, dbJsonString);
+                File file = read(this.getApplicationContext(), filename);
+                if (file.exists()) {
+                    Uri apkURI = FileProvider.getUriForFile(
+                            this.getApplicationContext(),
+                            this.getApplicationContext()
+                                    .getPackageName() + ".provider", file);
+                    intentShareFile.setDataAndType(apkURI, "application/json");
+                    intentShareFile.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    intentShareFile.putExtra(Intent.EXTRA_STREAM, apkURI);
+
+                    intentShareFile.putExtra(Intent.EXTRA_SUBJECT,
+                            "Exporting Food Tracker DB...");
+                    intentShareFile.putExtra(Intent.EXTRA_TEXT, "Exporting Food Tracker DB...");
+
+                    startActivity(Intent.createChooser(intentShareFile, "Share File"));
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void onClickImportBtn(View v) {
+        try {
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private boolean create(Context context, String fileName, String jsonString) {
+        try {
+            FileOutputStream fos = context.openFileOutput(fileName, Context.MODE_PRIVATE);
+            if (jsonString != null) {
+                fos.write(jsonString.getBytes());
+            }
+            fos.close();
+            return true;
+        } catch (FileNotFoundException fileNotFound) {
+            return false;
+        } catch (IOException ioException) {
+            return false;
+        }
+    }
+
+    private File read(Context context, String fileName) {
+        try {
+            File dbImpExFile = new File(context.getFileStreamPath(fileName).getAbsolutePath());
+            return dbImpExFile;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public boolean isFilePresent(Context context, String fileName) {
+        String path = context.getFilesDir().getAbsolutePath() + "/" + fileName;
+        File file = new File(path);
+        return file.exists();
+    }
+}

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/adapter/DatabaseFacade.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/adapter/DatabaseFacade.java
@@ -30,7 +30,6 @@ import org.secuso.privacyfriendlyfoodtracker.database.ProductDao;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 /**
  * Database access functions.
@@ -85,11 +84,11 @@ public class DatabaseFacade {
         Executors.newSingleThreadExecutor().execute(new Runnable() {
             @Override
             public void run() {
-                List<ConsumedEntries> res = consumedEntriesDao.findConsumedEntriesById(id);
-                if (res.size() != 1) {
+                ConsumedEntries res = consumedEntriesDao.findConsumedEntriesById(id);
+                if (null == res) {
                     return;
                 }
-                consumedEntriesDao.delete(res.get(0));
+                consumedEntriesDao.delete(res);
             }
         });
     }
@@ -103,13 +102,13 @@ public class DatabaseFacade {
         Executors.newSingleThreadExecutor().execute(new Runnable() {
             @Override
             public void run() {
-                List<ConsumedEntries> res = consumedEntriesDao.findConsumedEntriesById(id);
-                if (res.size() != 1) {
+                ConsumedEntries res = consumedEntriesDao.findConsumedEntriesById(id);
+                if (null == res) {
                     return;
                 }
-                ConsumedEntries consumedEntry = res.get(0);
+                ConsumedEntries consumedEntry = res;
                 consumedEntry.amount = amount;
-                consumedEntriesDao.update(res.get(0));
+                consumedEntriesDao.update(consumedEntry);
             }
         });
     }

--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/helper/BaseActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/helper/BaseActivity.java
@@ -34,9 +34,10 @@ import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
 
-import org.secuso.privacyfriendlyfoodtracker.ui.BaseStatisticActivity;
 import org.secuso.privacyfriendlyfoodtracker.R;
 import org.secuso.privacyfriendlyfoodtracker.ui.AboutActivity;
+import org.secuso.privacyfriendlyfoodtracker.ui.BaseStatisticActivity;
+import org.secuso.privacyfriendlyfoodtracker.ui.DatabaseActivity;
 import org.secuso.privacyfriendlyfoodtracker.ui.HelpActivity;
 import org.secuso.privacyfriendlyfoodtracker.ui.MainActivity;
 import org.secuso.privacyfriendlyfoodtracker.ui.TutorialActivity;
@@ -182,6 +183,10 @@ public abstract class BaseActivity extends AppCompatActivity implements OnNaviga
                 break;
             case R.id.nav_help:
                 intent = new Intent(this, HelpActivity.class);
+                createBackStack(intent);
+                break;
+            case R.id.nav_database:
+                intent = new Intent(this, DatabaseActivity.class);
                 createBackStack(intent);
                 break;
            /* case R.id.nav_settings:

--- a/app/src/main/res/layout/activity_database.xml
+++ b/app/src/main/res/layout/activity_database.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    tools:openDrawer="start">
+
+    <LinearLayout
+        android:id="@+id/main_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#FFFFFF"
+        android:fitsSystemWindows="true"
+        android:orientation="vertical"
+        android:weightSum="1">
+
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <include layout="@layout/toolbar" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/text_products"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/text_conssumedentries"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <Button
+                android:id="@+id/export_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:background="@color/colorPrimary"
+                android:onClick="onClickExportBtn"
+                android:text="@string/export_db"
+                android:textColor="@android:color/background_light"
+                android:theme="@style/AppTheme" />
+
+            <Button
+                android:id="@+id/export_products_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:background="@color/colorPrimary"
+                android:onClick="onClickExportBtn"
+                android:text="@string/export_products_db"
+                android:textColor="@android:color/background_light"
+                android:theme="@style/AppTheme" />
+
+        </LinearLayout>
+    </LinearLayout>
+
+    <android.support.design.widget.NavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:fitsSystemWindows="true"
+        app:headerLayout="@layout/nav_header_main"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/main_content_database"
+        app:layout_constraintTop_toTopOf="parent"
+        app:menu="@menu/main_drawer" />
+
+</android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/content_database.xml
+++ b/app/src/main/res/layout/content_database.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <fragment
+        android:id="@+id/nav_host_fragment_content_database"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/menu/main_drawer.xml
+++ b/app/src/main/res/menu/main_drawer.xml
@@ -12,6 +12,10 @@
             android:id="@+id/nav_statistic"
             android:icon="@mipmap/ic__chart"
             android:title="@string/action_statistic" />
+        <item
+            android:id="@+id/nav_database"
+            android:icon="@mipmap/ic__edit"
+            android:title="@string/action_database" />
     </group>
 
     <group android:id="@+id/nav_group_add"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -8,6 +8,7 @@
     <string name="action_settings">Einstellungen</string>
     <string name="action_main">Kalender</string>
     <string name="action_tutorial">Tutorial</string>
+    <string name="action_database">Datenbank</string>
 
     <string name="navigation_drawer_open">Öffne Navigation Drawer</string>
     <string name="navigation_drawer_close">Schliesse navigation drawer</string>
@@ -44,6 +45,7 @@
 
     <!-- ###SETTINGS### -->
     <string name="title_activity_settings">Einstellungen</string>
+    <string name="title_activity_database">Datenbank</string>
     <string name="pref_header_general">Allgemein</string>
     <string name="pref_example_switch">Schwebend</string>
     <string name="pref_example_switch_summary">Beispiel Switch Summary</string>
@@ -105,5 +107,11 @@
     <string name="save">Speichern</string>
 
     <string name="search_for">Nach einem Produkt suchen</string>
+    <string name="export_db">Ganze Datenbank teilen</string>
+    <string name="export_products_db">Produkt Datenbank teilen</string>
+    <string name="import_db">Datenbank importieren</string>
+    <string name="db_number_products">Anzahl Produkte in Datenbank:</string>
+    <string name="db_number_consumedentries">Anzahl konsumierter Einträge in Datenbank:</string>
+    <string name="title_activity_db_imp_exp_file_received">Datenbank</string>
 
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -7,6 +7,7 @@
     <string name="action_settings">Paramètres</string>
     <string name="action_main">Calendrier</string>
     <string name="action_tutorial">Tutoriel</string>
+    <string name="action_database">Database</string>
     <string name="help">Aide</string>
     <string name="help_whatis">Qu\'est-ce que Privacy Frendly Food Tracker ?</string>
     <string name="help_whatis_answer">Privacy Friendly Food Tracker est une application qui vous permet de suivre votre apport calorique tout en préservant votre vie privée.</string>
@@ -25,6 +26,7 @@
     <string name="privacy_friendly">Cette application appartient au groupe des applications respectueuses de la vie privée développées par le Karlsruhe Institute of Technology (KIT). Code source sous licence GPLv3. Images copyright KIT et Google Inc.</string>
     <string name="more_info">Plus d\'informations sur :</string>
     <string name="title_activity_settings">Paramètres</string>
+    <string name="title_activity_database">Databse</string>
     <string name="pref_header_general">Général</string>
     <string name="slide1_heading">Bienvenue !</string>
     <string name="slide1_text">Cette application vous aide à suivre votre apport calorique quotidien sans partager vos habitudes alimentaires avec des tiers. Pour garantir cela, elle ne nécessite aucune autorisation spéciale. La recherche fait cependant des demandes à une base de données en ligne (www.openfoodfacts.org). Cela pourrait potentiellement exposer certaines données sur vos habitudes alimentaires à la dites base de données. Si vous ne le souhaitez pas, vous pouvez tout simplement ne pas utiliser la recherche en ligne (aucune donnée n\'est envoyée tant que vous n\'avez pas appuyé sur le bouton de recherche).</string>
@@ -72,4 +74,10 @@
     <string name="pref_example_switch">Example Switch</string>
     <string name="pref_example_switch_summary">Example Switch Summary</string>
     <string name="pref_example_summary">Example Summary</string>
+    <string name="export_db">Share full DB</string>
+    <string name="export_products_db">Share Product DB only</string>
+    <string name="import_db">Import DB</string>
+    <string name="db_number_products">Number of products in database:</string>
+    <string name="db_number_consumedentries">Number of consumed entries in database:</string>
+    <string name="title_activity_db_imp_exp_file_received">Database</string>
 </resources>

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="fab_margin">48dp</dimen>
+</resources>

--- a/app/src/main/res/values-w1240dp/dimens.xml
+++ b/app/src/main/res/values-w1240dp/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="fab_margin">200dp</dimen>
+</resources>

--- a/app/src/main/res/values-w600dp/dimens.xml
+++ b/app/src/main/res/values-w600dp/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="fab_margin">48dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_settings">Settings</string>
     <string name="action_main">Calendar</string>
     <string name="action_tutorial">Tutorial</string>
+    <string name="action_database">Database</string>
 
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
@@ -46,6 +47,7 @@
 
     <!-- ###SETTINGS### -->
     <string name="title_activity_settings">Settings</string>
+    <string name="title_activity_database">Databse</string>
     <string name="pref_header_general">General</string>
     <string name="pref_example_switch">Example Switch</string>
     <string name="pref_example_switch_summary">Example Switch Summary</string>
@@ -110,4 +112,10 @@
     <string name="save">Save</string>
 
     <string name="search_for">Search for a product</string>
+    <string name="export_db">Share full DB</string>
+    <string name="export_products_db">Share Product DB only</string>
+    <string name="import_db">Import DB</string>
+    <string name="db_number_products">Number of products in database:</string>
+    <string name="db_number_consumedentries">Number of consumed entries in database:</string>
+    <string name="title_activity_db_imp_exp_file_received">Database</string>
 </resources>

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path
+        name="files"
+        path="." />
+</paths>


### PR DESCRIPTION
**Motivation:**
My partner and I both use the app, and since we eat the same things most of the time we had to maintain the same database entries on every device we use separately. Another use case is moving to a new device, by exporting the database file and re-importing it the user does not have to re-create everything he added in the past.
This implementation allows to share either the complete database or only the product database with someone else.

**Implementation details:**
A new navigation menu entry titled "Database" with the corresponding new activity `activity_database.xml` was added. The activity contains two buttons, one to export the whole DB and one to only export products. Exporter and importer are separate classes, each using the respective DAOs to get the full dataset from/into the database. The ConsumedEntities and Products are returned as Lists inside an `ImpExModel.java` instance. Gson is used to transform that data into a json string, which is then stored as a .json file inside the apps internal storage (for a possible future "Restore" functionality) and handed over to an Intent to share the file with any other app accepting them (e.g. a messenger app, a cloud storage for archiving,..)
Import is also handled via a "View" intent. Opening the .json file will either open it directly with the Food Tracker intent handler activity or will show a selection of possible Apps able to handle .json files.

Privacy