### PR TITLE
Add 'total calories' counter to 'Add a new entry' screen

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/AddFoodFragment.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/AddFoodFragment.java
@@ -17,8 +17,10 @@ along with Privacy friendly food tracker.  If not, see <https://www.gnu.org/lice
 package org.secuso.privacyfriendlyfoodtracker.ui;
 
 import android.os.Bundle;
+import android.text.Editable;
 import android.text.InputFilter;
 import android.text.InputType;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -53,6 +55,8 @@ public class AddFoodFragment extends Fragment {
     DatabaseFacade databaseFacade;
     EditText amountField;
     EditText caloriesField;
+    TextView totalCaloriesField;
+
     /**
      * The required empty public constructor
      */
@@ -87,7 +91,9 @@ public class AddFoodFragment extends Fragment {
         caloriesField = parentHolder.findViewById(R.id.input_calories);
         amountField.setFilters(amountFilter);
         amountField.setInputType(InputType.TYPE_CLASS_NUMBER);
+        amountField.addTextChangedListener(fieldChangedWatcher);
         caloriesField.setFilters(caloriesFilter);
+        caloriesField.addTextChangedListener(fieldChangedWatcher);
         FloatingActionButton fab = parentHolder.findViewById(R.id.addEntry);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -113,9 +119,41 @@ public class AddFoodFragment extends Fragment {
             }
         });
 
+        totalCaloriesField = parentHolder.findViewById(R.id.total_calories);
 
         return parentHolder;
     }
+
+    public void updateTotalCaloriesField() {
+        String message = "";
+
+        try {
+            int amount = Integer.parseInt(amountField.getText().toString());
+            double caloriesPerOneHundredG = Double.parseDouble(caloriesField.getText().toString());
+            message = String.format(Locale.ENGLISH, "%,.2f", caloriesPerOneHundredG * (amount / 100.0));
+        } catch (NumberFormatException e) {
+            message = "~";
+        }
+
+        totalCaloriesField.setText(String.format(getString(R.string.total_calories_n), message));
+    }
+
+    private final TextWatcher fieldChangedWatcher = new TextWatcher() {
+        @Override
+        public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+        }
+
+        @Override
+        public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+        }
+
+        @Override
+        public void afterTextChanged(Editable editable) {
+            updateTotalCaloriesField();
+        }
+    };
 
     /**
      * Called when the fragment is made visible to set correct presets for

--- a/app/src/main/res/layout-land/content_food.xml
+++ b/app/src/main/res/layout-land/content_food.xml
@@ -67,6 +67,12 @@
 
     </com.google.android.material.textfield.TextInputLayout>
 
+    <TextView
+        android:id="@+id/total_calories"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/inputCalories"
+        tools:text="Total Calories: 100"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/res/layout/content_food.xml
+++ b/app/src/main/res/layout/content_food.xml
@@ -69,6 +69,12 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
+        <TextView
+            android:id="@+id/total_calories"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@+id/inputCalories"
+            tools:text="Total Calories: 100"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -83,6 +83,7 @@
     <string name="action_confirm">Bestätigen</string>
     <string name="action_cancel">Abbrechen</string>
     <string name="delete_entry_prompt">Löschen?</string>
+    <string name="total_calories_n">Gesamtkalorien: %1$s</string>
 
     <string name="setup_step_generating_key">Erstelle Key</string>
     <string name="setup_step_generating_passphrase">Erstelle Passphrase</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,4 +72,5 @@
     <string name="pref_example_switch">Example Switch</string>
     <string name="pref_example_switch_summary">Example Switch Summary</string>
     <string name="pref_example_summary">Example Summary</string>
+    <string name="total_calories_n">Calories totales: %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_confirm">Confirm</string>
     <string name="action_cancel">Cancel</string>
     <string name="delete_entry_prompt">Delete?</string>
+    <string name="total_calories_n">Total Calories: %1$s</string>
 
 
     <string name="setup_step_generating_key">Generating Key</string>


### PR DESCRIPTION
Often when cooking I will use a kitchen scale to measure out amounts of food and enter the weight into this app. Something I found myself doing frequently was calculating the total calories when entering something into the 'add a new entry' screen. This pull request automates that calculation and displays it at the bottom of the form.

See https://imgur.com/a/6Cdr2XH for a video of this functionality in action.

I did not want to submit this PR with any active Android Studio warnings, thus I used Google Translate to provide a "total calories" string for both French and German. I do not speak either of these languages though and I am uncertain of the accuracy.
