### PR TITLE
Add calorie per 100g calculator to 'Add a new entry' screen

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/AddFoodFragment.java
+++ b/app/src/main/java/org/secuso/privacyfriendlyfoodtracker/ui/AddFoodFragment.java
@@ -63,6 +63,8 @@ public class AddFoodFragment extends Fragment {
     EditText amountField;
     TextInputLayout caloriesFieldLayout;
     EditText caloriesField;
+    TextView totalCaloriesField;
+
     /**
      * The required empty public constructor
      */
@@ -98,7 +100,9 @@ public class AddFoodFragment extends Fragment {
         caloriesField = parentHolder.findViewById(R.id.input_calories);
         amountField.setFilters(amountFilter);
         amountField.setInputType(InputType.TYPE_CLASS_NUMBER);
+        amountField.addTextChangedListener(fieldChangedWatcher);
         caloriesField.setFilters(caloriesFilter);
+        caloriesField.addTextChangedListener(fieldChangedWatcher);
         FloatingActionButton fab = parentHolder.findViewById(R.id.addEntry);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -124,9 +128,41 @@ public class AddFoodFragment extends Fragment {
             }
         });
 
+        totalCaloriesField = parentHolder.findViewById(R.id.total_calories);
 
         return parentHolder;
     }
+
+    public void updateTotalCaloriesField() {
+        String message = "";
+
+        try {
+            int amount = Integer.parseInt(amountField.getText().toString());
+            double caloriesPerOneHundredG = Double.parseDouble(caloriesField.getText().toString());
+            message = String.format(Locale.ENGLISH, "%,.2f", caloriesPerOneHundredG * (amount / 100.0));
+        } catch (NumberFormatException e) {
+            message = "~";
+        }
+
+        totalCaloriesField.setText(String.format(getString(R.string.total_calories_n), message));
+    }
+
+    private final TextWatcher fieldChangedWatcher = new TextWatcher() {
+        @Override
+        public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+        }
+
+        @Override
+        public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+        }
+
+        @Override
+        public void afterTextChanged(Editable editable) {
+            updateTotalCaloriesField();
+        }
+    };
 
     /**
      * Called when the fragment is made visible to set correct presets for

--- a/app/src/main/res/drawable/ic_calculate_24dp.xml
+++ b/app/src/main/res/drawable/ic_calculate_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5C21,3.9 20.1,3 19,3zM13.03,7.06L14.09,6l1.41,1.41L16.91,6l1.06,1.06l-1.41,1.41l1.41,1.41l-1.06,1.06L15.5,9.54l-1.41,1.41l-1.06,-1.06l1.41,-1.41L13.03,7.06zM6.25,7.72h5v1.5h-5V7.72zM11.5,16h-2v2H8v-2H6v-1.5h2v-2h1.5v2h2V16zM18,17.25h-5v-1.5h5V17.25zM18,14.75h-5v-1.5h5V14.75z"/>
+</vector>

--- a/app/src/main/res/layout-land/content_food.xml
+++ b/app/src/main/res/layout-land/content_food.xml
@@ -67,6 +67,12 @@
 
     </com.google.android.material.textfield.TextInputLayout>
 
+    <TextView
+        android:id="@+id/total_calories"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/inputCalories"
+        tools:text="Total Calories: 100"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>
     <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/res/layout/content_food.xml
+++ b/app/src/main/res/layout/content_food.xml
@@ -57,6 +57,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:errorEnabled="true"
+            app:endIconMode="custom"
+            app:endIconDrawable="@drawable/ic_calculate_24dp"
             app:layout_constraintTop_toBottomOf="@+id/inputFoodAmount">
 
             <EditText

--- a/app/src/main/res/layout/content_food.xml
+++ b/app/src/main/res/layout/content_food.xml
@@ -71,6 +71,12 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
+        <TextView
+            android:id="@+id/total_calories"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@+id/inputCalories"
+            tools:text="Total Calories: 100"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -83,6 +83,10 @@
     <string name="action_confirm">Bestätigen</string>
     <string name="action_cancel">Abbrechen</string>
     <string name="delete_entry_prompt">Löschen?</string>
+    <string name="grams">Gramm</string>
+    <string name="calories">Kalorien</string>
+    <string name="x_equals_n">%1$s = %2$s</string>
+    <string name="calculate_kcal_per_100g">Berechnung kCal/100g</string>
 
     <string name="setup_step_generating_key">Erstelle Key</string>
     <string name="setup_step_generating_passphrase">Erstelle Passphrase</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -87,6 +87,7 @@
     <string name="calories">Kalorien</string>
     <string name="x_equals_n">%1$s = %2$s</string>
     <string name="calculate_kcal_per_100g">Berechnung kCal/100g</string>
+    <string name="total_calories_n">Gesamtkalorien: %1$s</string>
 
     <string name="setup_step_generating_key">Erstelle Key</string>
     <string name="setup_step_generating_passphrase">Erstelle Passphrase</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -72,4 +72,8 @@
     <string name="pref_example_switch">Example Switch</string>
     <string name="pref_example_switch_summary">Example Switch Summary</string>
     <string name="pref_example_summary">Example Summary</string>
+    <string name="grams">Grammes</string>
+    <string name="calories">Calories</string>
+    <string name="x_equals_n">%1$s = %2$s</string>
+    <string name="calculate_kcal_per_100g">Calculer kCal/100g</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -76,4 +76,5 @@
     <string name="calories">Calories</string>
     <string name="x_equals_n">%1$s = %2$s</string>
     <string name="calculate_kcal_per_100g">Calculer kCal/100g</string>
+    <string name="total_calories_n">Calories totales: %1$s</string>
 </resources>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="id" name="tag_calories_per_calculator_result" />
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,10 @@
     <string name="action_confirm">Confirm</string>
     <string name="action_cancel">Cancel</string>
     <string name="delete_entry_prompt">Delete?</string>
+    <string name="grams">Grams</string>
+    <string name="calories">Calories</string>
+    <string name="x_equals_n">%1$s = %2$s</string>
+    <string name="calculate_kcal_per_100g">Calculate kCal/100g</string>
 
 
     <string name="setup_step_generating_key">Generating Key</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="calories">Calories</string>
     <string name="x_equals_n">%1$s = %2$s</string>
     <string name="calculate_kcal_per_100g">Calculate kCal/100g</string>
+    <string name="total_calories_n">Total Calories: %1$s</string>
 
 
     <string name="setup_step_generating_key">Generating Key</string>


### PR DESCRIPTION
I'm not sure how it works in other countries but in the USA, packaged food will often display the calories per serving size, where the serving size is listed in grams.

For example, I have a package of chocolate cookies in front of me right now. The serving size is 28 grams with a calorie count of 120.

I am often frustrated by this convention when inputting new food items into this app. Sometimes the math can be done in my head, but other times I need to switch to the calculator app.

In this PR, I add a calculator button to the "kCal/100g" field on the "add a new entry" screen. This calculator is a pop up dialog which lets you enter a calorie to gram ratio and then it calculates the "kCal/100g" value. When you click save, it places it into the field.

See https://imgur.com/a/sj21gj1 to view this functionality in action.

Once again, I have added German and French translations via Google Translate.

I also got the calculator icon (`ic_calculate_24dp.xml`) with the "add vector asset" tool in Android Studio.